### PR TITLE
[Image Lab React] Added cross-env package to set Browser env.

### DIFF
--- a/imagelab_react/package.json
+++ b/imagelab_react/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "blockly": "^9.3.3",
+    "cross-env": "^7.0.3",
     "electron": "^25.0.1",
     "electron-is-dev": "^2.0.0",
     "jimp": "^0.22.8",
@@ -28,7 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "dev": "concurrently -k \"BROWSER=none yarn start\" \"yarn:electron\"",
+    "dev": "concurrently -k \"cross-env BROWSER=none yarn start\" \"yarn:electron\"",
     "electron": "electron ."
   },
   "eslintConfig": {

--- a/imagelab_react/yarn.lock
+++ b/imagelab_react/yarn.lock
@@ -4015,7 +4015,14 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
# Description

Added a cross-env package in the node modules so that it can set env var BROWSER=none on running the command
'yarn dev' or 'npm run dev'.

![image](https://github.com/scorelab/imagelab/assets/107514366/3c257009-713f-410d-b5e2-63d5c60dac09)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On running the command 'yarn dev' or 'npm run dev', both the commands to start electron and react servers were starting properly and browser is set to none so that react server does not open browser, infact electron app is starting directly without any issue.

Also, include screenshots for verification and reviewing purpose.
![image](https://github.com/scorelab/imagelab/assets/107514366/111c3a99-d75f-4736-a2a2-f56598c00f69)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
