### PR TITLE
Feat: Add image flipping functionality to the Geometric Operator.

### DIFF
--- a/imagelab-blocks.js
+++ b/imagelab-blocks.js
@@ -149,6 +149,26 @@ Blockly.defineBlocksWithJsonArray([
       "Image Affine Translation or shearing express in a materix form. It's a combination of shearing and reflection",
     helpUrl: "",
   },
+  {
+    type: "flip_image",
+    message0: "Flip image with flip code %1",
+    args0: [
+      {
+        type: "field_dropdown",
+        name: "flip_code",
+        options: [
+          ["Vertical", "0"],
+          ["Horizontal", "1"],
+          ["Both", "-1"]
+        ]
+      }
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    colour: 20,
+    tooltip: "Flip the image vertically, horizontally, or both.",
+    helpUrl: ""
+  },
 
   //Convertions
   {

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
 
                   <block type="geometric_affineimage"></block>
                   <block type="geometric_scaleimage"></block>
+                  <block type="flip_image"></block>
                 </category>
                 <category
                   css-icon="customIcon mdi mdi-palette"

--- a/operations.js
+++ b/operations.js
@@ -25,6 +25,7 @@ const PROCESS_OPERATIONS = {
   MORPHOLOGICAL: "filtering_morphological",
   ADAPTIVETHRESHOLDING: "thresholding_adaptivethreshold",
   SIMPLETHRESHOLDING: "thresholding_applythreshold",
+  FLIP_IMAGE: "flip_image",
 };
 
 module.exports = PROCESS_OPERATIONS;

--- a/src/controller/main.js
+++ b/src/controller/main.js
@@ -22,6 +22,7 @@ const PyramidUp = require("../operator/filtering/PyramidUp");
 const AffineImage = require("../operator/geometric/AffineImage");
 const ReflectImage = require("../operator/geometric/ReflectImage");
 const RotateImage = require("../operator/geometric/RotateImage");
+const FlipImage = require("../operator/geometric/FlipImage");
 const ScaleImage = require("../operator/geometric/ScaleImage");
 const AdaptiveThreshold = require("../operator/thresholding/AdaptiveThresholding");
 const ApplyThreshold = require("../operator/thresholding/ApplyThreshold");
@@ -116,6 +117,11 @@ class MainController {
    */
   addOperator(operatorType, id) {
     switch (operatorType) {
+      case PROCESS_OPERATIONS.FLIP_IMAGE:
+        this.#appliedOperators.push(
+            new FlipImage(PROCESS_OPERATIONS.FLIP_IMAGE, id)
+        );
+        break;
       case PROCESS_OPERATIONS.READIMAGE:
         this.#appliedOperators.push(
           new ReadImage(PROCESS_OPERATIONS.READIMAGE, id)

--- a/src/operator/geometric/FlipImage.js
+++ b/src/operator/geometric/FlipImage.js
@@ -1,0 +1,50 @@
+const OpenCvOperator = require("../OpenCvOperator");
+
+class FlipImage extends OpenCvOperator {
+    #flipCode = 0; // 0: vertical, 1: horizontal, -1: both
+
+    constructor(type, id) {
+        super(type, id);
+    }
+
+    /**
+     * Sets the parameters for the FlipImage operation.
+     * @param {string} param - The parameter name.
+     * @param {number} value - The value to set for the parameter.
+     */
+    setParams(param, value) {
+        if (param === "flip_code") {
+            const numericValue = Number(value)
+            if (![0, 1, -1].includes(numericValue)) {
+                throw new Error("Invalid flip_code value. Allowed values: 0 (vertical), 1 (horizontal), -1 (both).");
+            }
+            this.#flipCode = value;
+        } else {
+            throw new Error(`Unknown parameter: ${param}`);
+        }
+    }
+
+    /**
+     * Computes the flip transformation on the given image.
+     * @param {cv.Mat} image - The image to be flipped.
+     * @returns {cv.Mat|null} - The flipped image or null if an error occurs.
+     */
+    compute(image) {
+        try {
+            if (!image || !(image instanceof cv.Mat)) {
+                console.log("Invalid image provided. Expected a valid OpenCV Mat object.");
+                return null;
+            }
+
+            let dst = new cv.Mat();
+            cv.flip(image, dst, this.#flipCode);
+            return dst;
+
+        } catch (error) {
+            console.error("Error in FlipImage.compute():", error.message);
+            return null;
+        }
+    }
+}
+
+module.exports = FlipImage;


### PR DESCRIPTION
# Description

This pull request includes the implementation of the FlipImage feature in the OpenCV configuration and Blockly configuration. The FlipImage feature allows users to flip an image vertically, horizontally, or both using a dropdown menu in the Blockly interface. The corresponding OpenCV operator processes the image based on the selected flip code.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**I don't see any new errors when I run the command `npm test -- --config=jest.config.js`, but I'll definitely add test cases for this code as well.**

```
Test Suites: 18 passed, 18 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        5.829 s
Ran all test suites.
```

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

Also, include screenshots for verification and reviewing purpose.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

