### PR TITLE
Fix Bootup error uncaught error message

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,8 @@ const path = require("path");
 
 const { app, BrowserWindow, Menu, shell } = electron;
 
+require("@electron/remote/main").initialize();
+
 let splash;
 
 require("electron-reload")(__dirname, {
@@ -31,6 +33,8 @@ app.on("ready", () => {
     frame: false,
     titleBarStyle: "hidden",
   });
+
+  require("@electron/remote/main").enable(mainWindow.webContents);
 
   // Splash window properties
   splash = new BrowserWindow({
@@ -81,21 +85,21 @@ const template = [
   // { role: 'appMenu' }
   ...(isMac
     ? [
-        {
-          label: app.name,
-          submenu: [
-            { role: "about" },
-            { type: "separator" },
-            { role: "services" },
-            { type: "separator" },
-            { role: "hide" },
-            { role: "hideothers" },
-            { role: "unhide" },
-            { type: "separator" },
-            { role: "quit" },
-          ],
-        },
-      ]
+      {
+        label: app.name,
+        submenu: [
+          { role: "about" },
+          { type: "separator" },
+          { role: "services" },
+          { type: "separator" },
+          { role: "hide" },
+          { role: "hideothers" },
+          { role: "unhide" },
+          { type: "separator" },
+          { role: "quit" },
+        ],
+      },
+    ]
     : []),
   // { role: 'fileMenu' }
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@blockly/continuous-toolbox": "^1.0.12",
         "@blockly/field-slider": "^2.1.22",
         "@blockly/plugin-workspace-search": "^4.0.3",
+        "@electron/remote": "^2.1.3",
         "@mdi/font": "^5.9.55",
         "blockly": "^6.20210701.0",
         "custom-electron-titlebar": "^3.2.10",
@@ -76,11 +77,12 @@
       }
     },
     "node_modules/@electron/remote": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-1.2.2.tgz",
-      "integrity": "sha512-PfnXpQGWh4vpX866NNucJRnNOzDRZcsLcLaT32fUth9k0hccsohfxprqEDYLzRg+ZK2xRrtyUN5wYYoHimMCJg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+      "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
+      "license": "MIT",
       "peerDependencies": {
-        "electron": ">= 10.0.0-beta.1"
+        "electron": ">= 13.0.0"
       }
     },
     "node_modules/@mdi/font": {
@@ -435,6 +437,15 @@
       "peerDependencies": {
         "@types/node": "^17.0.0",
         "electron": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || 15.0.0 || 16.0.0"
+      }
+    },
+    "node_modules/custom-electron-titlebar/node_modules/@electron/remote": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-1.2.2.tgz",
+      "integrity": "sha512-PfnXpQGWh4vpX866NNucJRnNOzDRZcsLcLaT32fUth9k0hccsohfxprqEDYLzRg+ZK2xRrtyUN5wYYoHimMCJg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">= 10.0.0-beta.1"
       }
     },
     "node_modules/dashdash": {
@@ -2073,9 +2084,9 @@
       }
     },
     "@electron/remote": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-1.2.2.tgz",
-      "integrity": "sha512-PfnXpQGWh4vpX866NNucJRnNOzDRZcsLcLaT32fUth9k0hccsohfxprqEDYLzRg+ZK2xRrtyUN5wYYoHimMCJg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.1.3.tgz",
+      "integrity": "sha512-XlpxC8S4ttj/v2d+PKp9na/3Ev8bV7YWNL7Cw5b9MAWgTphEml7iYgbc7V0r9D6yDOfOkj06bchZgOZdlWJGNA==",
       "requires": {}
     },
     "@mdi/font": {
@@ -2357,6 +2368,14 @@
       "integrity": "sha512-l2DRcuGzMGRHw5yDtcmmEve4DwVoWoJxWtsPrXeEePmWfrG3vA90eMtcbk1+qzHTrBPOpnNbVBJakdTNoxZIMQ==",
       "requires": {
         "@electron/remote": "^1.0.0"
+      },
+      "dependencies": {
+        "@electron/remote": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-1.2.2.tgz",
+          "integrity": "sha512-PfnXpQGWh4vpX866NNucJRnNOzDRZcsLcLaT32fUth9k0hccsohfxprqEDYLzRg+ZK2xRrtyUN5wYYoHimMCJg==",
+          "requires": {}
+        }
       }
     },
     "dashdash": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@blockly/continuous-toolbox": "^1.0.12",
     "@blockly/field-slider": "^2.1.22",
     "@blockly/plugin-workspace-search": "^4.0.3",
+    "@electron/remote": "^2.1.3",
     "@mdi/font": "^5.9.55",
     "blockly": "^6.20210701.0",
     "custom-electron-titlebar": "^3.2.10",


### PR DESCRIPTION
# Description

This PR fixes a critical boot error (Uncaught TypeError: Cannot read property 'members' of undefined) caused by the deprecation of the remote module in Electron 13+. The application was failing to initialize the custom title bar because it relied on remote being available by default.

To fix this, I migrated the application to use the @electron/remote package, which is the official replacement for the built-in remote module in Electron 14+.

Dependencies added:

@electron/remote

Fixes #21 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have manually ran the start command to test and observe the logs if they still persist. They did not


**Test Configuration**:

- Firmware version: N/A
- Hardware: MacOS
- Toolchain: Node js, electron
- SDK: N/A
Also, include screenshots for verification and reviewing purpose.

Other errors are not relevant to this issue and will be fixed by my next few PR's
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/068edef2-ab38-4687-b2be-096b5fa64bad" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
