### PR TITLE
Undefined in the workspace on deselecting an operation block

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -43,11 +43,14 @@ Blockly.VerticalFlyout.prototype.getFlyoutScale = function () {
 // Coloring the information-pane when you select a block.
 workspace.addChangeListener(function (event) {
   if (event.type === Blockly.Events.SELECTED) {
-    document.getElementById("operator_name").innerText = workspace.getBlockById(
-      event.newElementId
-    )?.type;
-    document.getElementById("operator_description").innerText =
-      workspace.getBlockById(event.newElementId)?.tooltip;
+    const block = workspace.getBlockById(event.newElementId);
+    if (block) {
+      document.getElementById("operator_name").innerText = block.type;
+      document.getElementById("operator_description").innerText = block.tooltip;
+    } else {
+      document.getElementById("operator_name").innerText = "Operation name";
+      document.getElementById("operator_description").innerText = "here is the operation description";
+    }
   }
   if (event.type === Blockly.Events.BLOCK_CREATE) {
     mainController.addOperator(
@@ -199,7 +202,7 @@ function resetWorkspace() {
  */
 function downloadImage() {
   const downloadImage = mainController.getProcessedImage();
-  if(downloadImage != null) {
+  if (downloadImage != null) {
     var link = document.createElement("a");
     link.download = "Processed_image.jpg";
     link.href = downloadImage;


### PR DESCRIPTION
# Description

Fixed a bug where the information pane displayed "undefined" for the operation name and description when a block was deselected in the workspace. Added a check to ensure a valid block is selected before updating the UI, reverting to default text otherwise.

Fixes #23 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested by dragging a block to the workspace, selecting it to see details, and then clicking the background to deselect it. Verified that the text reverts to default instead of showing "undefined".

- [ ] Manual Verification: Selected a block, then deselected it by clicking the background workspace. Observed that the information pane text reset correctly.

**Test Configuration**:

- Firmware version: N/A
- Hardware: macbook m2 pro
- Toolchain: Node js, html, electron
- SDK:

Also, include screenshots for verification and reviewing purpose.

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/9122621a-77cf-4d67-b15f-bb602f85598e" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
