### PR TITLE
Initial Setup Error and preview Image not displaying error

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,8 @@ const path = require("path");
 const { app, BrowserWindow, Menu, shell } = electron;
 
 let splash;
+const remoteMain = require('@electron/remote/main');
+remoteMain.initialize();
 
 require("electron-reload")(__dirname, {
   electron: path.join(__dirname, "node_modules", ".bin", "electron"),

--- a/src/controller/main.js
+++ b/src/controller/main.js
@@ -251,8 +251,9 @@ class MainController {
 
   /**
    * This method compute and generate the output of the selected operators
+   * @param {Canvas} preview - The canvas element to display the processed image
    */
-  computeAll() {
+  computeAll(preview) {
     if (this.#appliedOperators.length === 0) {
       throw Error("No operators are added to the workspace");
     }
@@ -273,6 +274,16 @@ class MainController {
         }
       }
     });
+
+    // Render the processed image to the preview canvas
+    if (preview && this.#processedImage) {
+      const ctx = preview.getContext("2d");
+      preview.width = this.#processedImage.cols;
+      preview.height = this.#processedImage.rows;
+      const imageData = ctx.createImageData(this.#processedImage.cols, this.#processedImage.rows);
+      imageData.data.set(new Uint8ClampedArray(this.#processedImage.data));
+      ctx.putImageData(imageData, 0, 0);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #29 

# Description
The preview canvas does not display the processed image after executing image processing operations.Along with that fixed the error: Uncaught TypeError: Cannot read property 'members' of undefined

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manually tested
Before fix: Preview canvas remained blank after image processing.
After fix: Preview canvas updates correctly and displays processed image.

Before:
https://github.com/user-attachments/assets/2d7605eb-bbfb-448a-a98e-2f342be1f754

After:

https://github.com/user-attachments/assets/5aa3e012-06b0-4780-9bbb-bcb9a5a5fe56



- Environment:
- OS: Linux lite
- Browser: Chrome

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
