### PR TITLE
feature: add clear image button to preview pane

### DIFF
--- a/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
+++ b/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
@@ -38,6 +38,12 @@ function initReadImageBlock(block: Blockly.Block) {
       fileInput.click();
     });
   }
+  
+  // Register a reset callback when the image is cleared
+  usePipelineStore.getState().registerImageReset(() => {
+    const label = block.getField("filename_label");
+    if (label) label.setValue("No image");
+  });
 
   // Clean up on block disposal
   block.dispose = new Proxy(block.dispose, {

--- a/imagelab-frontend/src/components/Preview/PreviewPane.tsx
+++ b/imagelab-frontend/src/components/Preview/PreviewPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ZoomIn, ZoomOut, Image, ImageDown } from "lucide-react";
+import { ZoomIn, ZoomOut, Image, ImageDown, Trash2 } from "lucide-react";
 import { usePipelineStore } from "../../store/pipelineStore";
 import ImageDisplay from "./ImageDisplay";
 
@@ -35,7 +35,7 @@ function ZoomControls({
 }
 
 export default function PreviewPane() {
-  const { originalImage, imageFormat, processedImage, error } = usePipelineStore();
+  const { originalImage, imageFormat, processedImage, error, clearImage } = usePipelineStore();
 
   const [originalZoom, setOriginalZoom] = useState<number | null>(null);
   const [processedZoom, setProcessedZoom] = useState<number | null>(null);
@@ -52,6 +52,15 @@ export default function PreviewPane() {
         <div className="px-3 py-1.5 border-b border-gray-200 flex items-center gap-1.5">
           <Image size={14} className="text-gray-400" />
           <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Original</h2>
+          {originalImage && (
+            <button
+              onClick={clearImage}
+              className="ml-auto p-1 rounded hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
+              title="Remove image"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
         </div>
         <div className="flex-1 flex items-center justify-center p-3 bg-gray-50 overflow-auto">
           {originalImage ? (

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -15,6 +15,9 @@ interface PipelineState {
   setError: (error: string | null, step?: number | null) => void;
   setSelectedBlock: (type: string | null, tooltip: string | null) => void;
   reset: () => void;
+  clearImage: () => void;
+  _imageResetFn: (() => void) | null;
+  registerImageReset: (fn: () => void) => void;
 }
 
 export const usePipelineStore = create<PipelineState>((set) => ({
@@ -32,4 +35,12 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   setError: (error, step = null) => set({ error, errorStep: step }),
   setSelectedBlock: (type, tooltip) => set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
   reset: () => set({ originalImage: null, imageFormat: 'png', processedImage: null, isExecuting: false, error: null, errorStep: null, selectedBlockType: null, selectedBlockTooltip: null }),
+  _imageResetFn: null as (() => void) | null,
+  registerImageReset: (fn) => set({ _imageResetFn: fn }),
+  clearImage: () => {
+    const state = usePipelineStore.getState();
+    if (state._imageResetFn) state._imageResetFn();
+    set({ originalImage: null, processedImage: null, error: null, errorStep: null });
+  },
+
 }));


### PR DESCRIPTION
## Description

Added a trash icon button in the preview pane, allowing users to clear the uploaded image without resetting the entire workspace. Previously, the only ways to remove an uploaded image were reloading the page, using the "New" button which clears all blocks as well, or uploading a different image to replace it.

Fixes #34 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

Manually tested the following:
1. Uploaded an image using the Read Image block and confirmed the trash icon appears
2. Clicked the trash icon and confirmed both the original and processed images are cleared from the preview
3. Confirmed the Read Image block resets to "No image"
4. Confirmed all blocks and connections in the workspace remain intact after clearing

## Screenshots 

before the image is removed
<img width="1399" height="758" alt="before" src="https://github.com/user-attachments/assets/9c3105f8-abdc-4c47-8730-f721198c71bd" />

after the image is removed
<img width="1397" height="757" alt="after" src="https://github.com/user-attachments/assets/41e588d2-d945-4087-9e27-a2fcfab02773" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally (no test suite available for the frontend)