### PR TITLE
Feature: Otsu Threshold Implementation

### DIFF
--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -28,6 +28,7 @@ from app.operators.geometric.scale_image import ScaleImage
 from app.operators.sobel_derivatives.scharr_derivative import ScharrDerivative
 from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
 from app.operators.thresholding.adaptive_threshold import AdaptiveThreshold
+from app.operators.thresholding.otsu_threshold import OtsuThreshold
 from app.operators.thresholding.apply_borders import ApplyBorders
 from app.operators.thresholding.apply_threshold import ApplyThreshold
 from app.operators.transformation.distance_transform import DistanceTransform
@@ -70,6 +71,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "thresholding_applythreshold": ApplyThreshold,
     "thresholding_adaptivethreshold": AdaptiveThreshold,
     "thresholding_applyborders": ApplyBorders,
+    "thresholding_otsuthreshold": OtsuThreshold,
     # Sobel Derivatives
     "sobelderivatives_soblederivate": SobelDerivative,
     "sobelderivatives_scharrderivate": ScharrDerivative,

--- a/imagelab-backend/app/operators/thresholding/otsu_threshold.py
+++ b/imagelab-backend/app/operators/thresholding/otsu_threshold.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class OtsuThreshold(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        max_value = float(self.params.get("maxValue", 255))
+        # Convert to grayscale if not already
+        if len(image.shape) == 3:
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        _, image = cv2.threshold(
+            image,
+            0,
+            int(max_value),
+            cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+        )
+        return image

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -88,7 +88,8 @@ export const categories: CategoryInfo[] = [
       { type: "thresholding_applythreshold", label: "Apply Threshold" },
       { type: "thresholding_applyborders", label: "Apply Borders" },
       { type: "border_for_all", label: "Border (All Sides)" },
-      { type: "border_each_side", label: "Border (Each Side)" }
+      { type: "border_each_side", label: "Border (Each Side)" },
+      { type: "thresholding_otsuthreshold", label: "Otsu Threshold" },
     ]
   },
   {

--- a/imagelab-frontend/src/blocks/definitions/thresholding.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/thresholding.blocks.ts
@@ -23,6 +23,17 @@ export const thresholdingBlocks = [
     tooltip: "Applies adaptive Gaussian thresholding"
   },
   {
+    type: "thresholding_otsuthreshold",
+    message0: "Apply Otsu threshold with max value %1",
+    args0: [
+      { type: "field_number", name: "maxValue", value: 255, min: 0, max:255 }
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "thresholding_style",
+    tooltip: "Automatically calculates optimal threshold using Otsu's method"
+  },
+  {
     type: "thresholding_applyborders",
     message0: "Apply borders %1",
     args0: [


### PR DESCRIPTION
## Description
This PR implements the Otsu Threshold operator, an automatic thresholding feature that calculates the optimal threshold value by analyzing image histogram and maximizing between-class variance. Automatic threshold calculation (no manual tuning needed)

Fixes #36 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
It has been manually tested
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots
<img width="1277" height="566" alt="image" src="https://github.com/user-attachments/assets/1517703b-561a-47cd-ab69-ee2bad5459ba" />

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
