### PR TITLE
feat: expose adaptive threshold parameters in backend and blockly UI

### DIFF
--- a/imagelab-backend/alembic/env.py
+++ b/imagelab-backend/alembic/env.py
@@ -1,12 +1,11 @@
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
 
 from alembic import context
-
-from app.config import get_settings
-from sqlmodel import SQLModel
 from app import models  # noqa: F401
+from app.config import get_settings
 
 config = context.config
 config.set_main_option("sqlalchemy.url", get_settings().database_url)

--- a/imagelab-backend/app/database.py
+++ b/imagelab-backend/app/database.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, create_engine
 
 from app.config import get_settings
 

--- a/imagelab-backend/app/main.py
+++ b/imagelab-backend/app/main.py
@@ -14,8 +14,9 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app):
     """Application startup/shutdown lifecycle."""
-    from alembic import command
     from alembic.config import Config
+
+    from alembic import command
 
     cfg = Config("alembic.ini")
     try:

--- a/imagelab-backend/app/operators/thresholding/adaptive_threshold.py
+++ b/imagelab-backend/app/operators/thresholding/adaptive_threshold.py
@@ -6,15 +6,34 @@ from app.operators.base import BaseOperator
 
 class AdaptiveThreshold(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        max_value = float(self.params.get("maxValue", 0))
-        # Convert to grayscale if not already
+        max_value = float(self.params.get("maxValue", 255))
+        max_value = max(0, min(255, max_value))
+        
+        method_str = str(self.params.get("adaptiveMethod", "GAUSSIAN")).upper()
+        adaptive_method = cv2.ADAPTIVE_THRESH_MEAN_C if method_str == "MEAN" else cv2.ADAPTIVE_THRESH_GAUSSIAN_C
+            
+        block_size = int(self.params.get("blockSize", 3))
+        if block_size < 3:
+            block_size = 3
+        elif block_size % 2 == 0:
+            block_size += 1
+            
+        c_value = float(self.params.get("cValue", 2))
+
         if len(image.shape) == 3:
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            if image.shape[2] == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+                
+        if image.dtype != np.uint8:
+            image = image.astype(np.uint8)
+
         return cv2.adaptiveThreshold(
             image,
             max_value,
-            cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            adaptive_method,
             cv2.THRESH_BINARY,
-            3,
-            2,
+            block_size,
+            c_value,
         )

--- a/imagelab-frontend/src/blocks/definitions/thresholding.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/thresholding.blocks.ts
@@ -13,20 +13,30 @@ export const thresholdingBlocks = [
   },
   {
     type: "thresholding_adaptivethreshold",
-    message0: "Apply adaptive threshold with max value %1",
+    message0: "Apply adaptive threshold method %1 block size %2 C %3 max value %4",
     args0: [
-      { type: "field_number", name: "maxValue", value: 0, min: 0 }
+      {
+        type: "field_dropdown",
+        name: "adaptiveMethod",
+        options: [
+          ["GAUSSIAN", "GAUSSIAN"],
+          ["MEAN", "MEAN"]
+        ]
+      },
+      { type: "field_number", name: "blockSize", value: 3, min: 3, precision: 1 },
+      { type: "field_number", name: "cValue", value: 2 },
+      { type: "field_number", name: "maxValue", value: 255, min: 0, max: 255 }
     ],
     previousStatement: null,
     nextStatement: null,
     style: "thresholding_style",
-    tooltip: "Applies adaptive Gaussian thresholding - This method calculates the threshold for a pixel based on a small region around it, allowing for varying lighting conditions across the image. The 'maxValue' parameter sets the value to assign to pixels that exceed the threshold. This is particularly useful for images with uneven illumination."
+    tooltip: "Applies adaptive Gaussian or Mean thresholding - This method calculates the threshold for a pixel based on a small region around it, allowing for varying lighting conditions across the image. The 'maxValue' parameter sets the value to assign to pixels that exceed the threshold. This is particularly useful for images with uneven illumination."
   },
   {
     type: "thresholding_otsuthreshold",
     message0: "Apply Otsu threshold with max value %1",
     args0: [
-      { type: "field_number", name: "maxValue", value: 255, min: 0, max:255 }
+      { type: "field_number", name: "maxValue", value: 255, min: 0, max: 255 }
     ],
     previousStatement: null,
     nextStatement: null,


### PR DESCRIPTION
## Description

Improved the `Adaptive Threshold` operator by fully exposing its underlying parameters to the user interface, allowing fine-grained control over the thresholding calculation.

- **Backend Implementations**: Updated [app/operators/thresholding/adaptive_threshold.py](cci:7://file:///c:/Users/jayan/Desktop/c2si%20imag%20lab/imagelab-c2si-gsoc/imagelab-backend/app/operators/thresholding/adaptive_threshold.py:0:0-0:0) to dynamically parse parameter values from `self.params`. Added proper validation and clamping logic for `adaptiveMethod` (MEAN/GAUSSIAN), `blockSize` (ensured to be an odd integer $\geq$ 3), `cValue` (float), and `maxValue` (clamped strictly to 0-255).
- **Frontend Implementations**: Expanded the `thresholding_adaptivethreshold` block definition in [src/blocks/definitions/thresholding.blocks.ts](cci:7://file:///c:/Users/jayan/Desktop/c2si%20imag%20lab/imagelab-c2si-gsoc/imagelab-frontend/src/blocks/definitions/thresholding.blocks.ts:0:0-0:0) to include interactive input fields for the parameters, including a dedicated dropdown specifically for selecting the `adaptiveMethod`.

Fixes #64

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Verified in both the local React frontend and FastAPI backend by adding the updated "Adaptive Threshold" block into an active pipeline.
- **Dynamic Parameter Interaction**: Verified that adjusting the `blockSize` and `cValue` numeric inputs within the UI successfully alters the thresholding output on the canvas in real-time.
- **Method Swapping**: Confirmed that toggling the dropdown between MEAN and GAUSSIAN correctly switches the underlying OpenCV thresholding algorithm applied.
- **Validation Fallbacks**: Tested edge-cases (like entering even numbers for block size) to ensure the backend gracefully handles and normalizes out-of-bounds parameters without crashing the pipeline.
- **Automated Checks**: Verified clean passes across backend `pytest`, backend `ruff`, and frontend `eslint`.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
