### PR TITLE
feat: add channel split operator with Blockly dropdown

### DIFF
--- a/imagelab-backend/app/operators/conversions/channel_split.py
+++ b/imagelab-backend/app/operators/conversions/channel_split.py
@@ -1,0 +1,26 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class ChannelSplit(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        channel_str = str(self.params.get("channel", "RED")).upper()
+        
+        channel_idx = 2  # RED (Default)
+        if channel_str == "BLUE":
+            channel_idx = 0
+        elif channel_str == "GREEN":
+            channel_idx = 1
+            
+        # Return image as-is if it's already single-channel/grayscale
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            return image
+            
+        # Split channels if image has 3 or more channels (e.g. BGR or BGRA)
+        if len(image.shape) == 3 and image.shape[2] >= 3:
+            channels = cv2.split(image)
+            return channels[channel_idx]
+            
+        return image

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -4,6 +4,7 @@ from app.operators.basic.write_image import WriteImage
 from app.operators.blurring.blur import Blur
 from app.operators.blurring.gaussian_blur import GaussianBlur
 from app.operators.blurring.median_blur import MedianBlur
+from app.operators.conversions.channel_split import ChannelSplit
 from app.operators.conversions.color_maps import ColorMaps
 from app.operators.conversions.color_to_binary import ColorToBinary
 from app.operators.conversions.gray_image import GrayImage
@@ -44,6 +45,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "geometric_affineimage": AffineImage,
     # Conversions
     "imageconvertions_grayimage": GrayImage,
+    "imageconvertions_channelsplit": ChannelSplit,
     "imageconvertions_graytobinary": GrayToBinary,
     "imageconvertions_colormaps": ColorMaps,
     "imageconvertions_colortobinary": ColorToBinary,

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -37,6 +37,7 @@ export const categories: CategoryInfo[] = [
     colour: "#FF8A65",
     blocks: [
       { type: "imageconvertions_grayimage", label: "Gray Image" },
+      { type: "imageconvertions_channelsplit", label: "Channel Split" },
       { type: "imageconvertions_graytobinary", label: "Gray to Binary" },
       { type: "imageconvertions_colormaps", label: "Color Maps" },
       { type: "imageconvertions_colortobinary", label: "Color to Binary" }

--- a/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
@@ -8,6 +8,25 @@ export const conversionsBlocks = [
     tooltip: "Converts the image to grayscale"
   },
   {
+    type: "imageconvertions_channelsplit",
+    message0: "Extract %1 channel from image",
+    args0: [
+      {
+        type: "field_dropdown",
+        name: "channel",
+        options: [
+          ["Red", "RED"],
+          ["Green", "GREEN"],
+          ["Blue", "BLUE"]
+        ]
+      }
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Splits a multi-channel image and extracts the selected channel as grayscale"
+  },
+  {
     type: "imageconvertions_graytobinary",
     message0: "Convert grayscale image to a binary one %1 with threshold value %2 and max value %3",
     args0: [


### PR DESCRIPTION
## Description

Added a new `Channel Split` operator that extracts a single color channel (BLUE, GREEN, RED) from a multi-channel image and returns it as a compatible single-channel grayscale image.

- **Backend**: Implemented the [ChannelSplit](cci:2://file:///c:/Users/jayan/Desktop/c2si%20imag%20lab/imagelab-c2si-gsoc/imagelab-backend/app/operators/conversions/channel_split.py:6:0-25:20) operator in [channel_split.py](cci:7://file:///c:/Users/jayan/Desktop/c2si%20imag%20lab/imagelab-c2si-gsoc/imagelab-backend/app/operators/conversions/channel_split.py:0:0-0:0). The operator retrieves the user's `channel` parameter, automatically assumes index mappings (B=0, G=1, R=2), handles grayscale inputs gracefully by returning them unchanged, and splits 3-channel images using `cv2.split()`. It is registered under the `conversions` dictionary (`imageconvertions_channelsplit`).
- **Frontend**: Added a Blockly block (`imageconvertions_channelsplit`) in the Conversions category with an intuitive dropdown to select between Red, Green, and Blue channels.

Fixes #63

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Verified in both the local React frontend and FastAPI backend by adding the "Channel Split" Conversions block into a pipeline containing an image.
- **Visual Verification**: Confirmed that selecting `RED` on a red-heavy image produced a bright grayscale result, while selecting `BLUE` returned a correctly darkened result.
- **Grayscale images**: Verified that sending an already-grayscale image into the block gracefully processes without exceptions and outputs the identical grayscale structure.
- **Automated**: Clean passes across backend `pytest`, backend `ruff`, and frontend `eslint`.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
