### PR TITLE
feat: add color space conversion blocks (HSV, LAB, YCrCb)

### DIFF
--- a/imagelab-backend/alembic/env.py
+++ b/imagelab-backend/alembic/env.py
@@ -1,12 +1,11 @@
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
 
 from alembic import context
-
-from app.config import get_settings
-from sqlmodel import SQLModel
 from app import models  # noqa: F401
+from app.config import get_settings
 
 config = context.config
 config.set_main_option("sqlalchemy.url", get_settings().database_url)

--- a/imagelab-backend/app/database.py
+++ b/imagelab-backend/app/database.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import Session, create_engine
 
 from app.config import get_settings
 

--- a/imagelab-backend/app/main.py
+++ b/imagelab-backend/app/main.py
@@ -14,8 +14,9 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app):
     """Application startup/shutdown lifecycle."""
-    from alembic import command
     from alembic.config import Config
+
+    from alembic import command
 
     cfg = Config("alembic.ini")
     try:

--- a/imagelab-backend/app/operators/conversions/bgr_to_hsv.py
+++ b/imagelab-backend/app/operators/conversions/bgr_to_hsv.py
@@ -1,0 +1,14 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class BgrToHsv(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+        elif len(image.shape) == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+            
+        return cv2.cvtColor(image, cv2.COLOR_BGR2HSV)

--- a/imagelab-backend/app/operators/conversions/bgr_to_lab.py
+++ b/imagelab-backend/app/operators/conversions/bgr_to_lab.py
@@ -1,0 +1,14 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class BgrToLab(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+        elif len(image.shape) == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+            
+        return cv2.cvtColor(image, cv2.COLOR_BGR2LAB)

--- a/imagelab-backend/app/operators/conversions/bgr_to_ycrcb.py
+++ b/imagelab-backend/app/operators/conversions/bgr_to_ycrcb.py
@@ -1,0 +1,14 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class BgrToYcrcb(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+        elif len(image.shape) == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+            
+        return cv2.cvtColor(image, cv2.COLOR_BGR2YCrCb)

--- a/imagelab-backend/app/operators/conversions/hsv_to_bgr.py
+++ b/imagelab-backend/app/operators/conversions/hsv_to_bgr.py
@@ -1,0 +1,17 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class HsvToBgr(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+            
+        if len(image.shape) == 3 and image.shape[2] >= 3:
+            if image.shape[2] == 4:
+                image = image[:, :, :3]
+            return cv2.cvtColor(image, cv2.COLOR_HSV2BGR)
+            
+        return image

--- a/imagelab-backend/app/operators/conversions/lab_to_bgr.py
+++ b/imagelab-backend/app/operators/conversions/lab_to_bgr.py
@@ -1,0 +1,17 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class LabToBgr(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+            
+        if len(image.shape) == 3 and image.shape[2] >= 3:
+            if image.shape[2] == 4:
+                image = image[:, :, :3]
+            return cv2.cvtColor(image, cv2.COLOR_LAB2BGR)
+            
+        return image

--- a/imagelab-backend/app/operators/conversions/ycrcb_to_bgr.py
+++ b/imagelab-backend/app/operators/conversions/ycrcb_to_bgr.py
@@ -1,0 +1,17 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class YcrcbToBgr(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if len(image.shape) == 2 or (len(image.shape) == 3 and image.shape[2] == 1):
+            return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+            
+        if len(image.shape) == 3 and image.shape[2] >= 3:
+            if image.shape[2] == 4:
+                image = image[:, :, :3]
+            return cv2.cvtColor(image, cv2.COLOR_YCrCb2BGR)
+            
+        return image

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -4,11 +4,17 @@ from app.operators.basic.write_image import WriteImage
 from app.operators.blurring.blur import Blur
 from app.operators.blurring.gaussian_blur import GaussianBlur
 from app.operators.blurring.median_blur import MedianBlur
+from app.operators.conversions.bgr_to_hsv import BgrToHsv
+from app.operators.conversions.bgr_to_lab import BgrToLab
+from app.operators.conversions.bgr_to_ycrcb import BgrToYcrcb
 from app.operators.conversions.channel_split import ChannelSplit
 from app.operators.conversions.color_maps import ColorMaps
 from app.operators.conversions.color_to_binary import ColorToBinary
 from app.operators.conversions.gray_image import GrayImage
 from app.operators.conversions.gray_to_binary import GrayToBinary
+from app.operators.conversions.hsv_to_bgr import HsvToBgr
+from app.operators.conversions.lab_to_bgr import LabToBgr
+from app.operators.conversions.ycrcb_to_bgr import YcrcbToBgr
 from app.operators.drawing.draw_arrow_line import DrawArrowLine
 from app.operators.drawing.draw_circle import DrawCircle
 from app.operators.drawing.draw_ellipse import DrawEllipse
@@ -53,6 +59,12 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "imageconvertions_graytobinary": GrayToBinary,
     "imageconvertions_colormaps": ColorMaps,
     "imageconvertions_colortobinary": ColorToBinary,
+    "imageconvertions_bgrtohsv": BgrToHsv,
+    "imageconvertions_hsvtobgr": HsvToBgr,
+    "imageconvertions_bgrtolab": BgrToLab,
+    "imageconvertions_labtobgr": LabToBgr,
+    "imageconvertions_bgrtoycrcb": BgrToYcrcb,
+    "imageconvertions_ycrcbtobgr": YcrcbToBgr,
     # Drawing
     "drawingoperations_drawline": DrawLine,
     "drawingoperations_drawcircle": DrawCircle,

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -41,7 +41,13 @@ export const categories: CategoryInfo[] = [
       { type: "imageconvertions_channelsplit", label: "Channel Split" },
       { type: "imageconvertions_graytobinary", label: "Gray to Binary" },
       { type: "imageconvertions_colormaps", label: "Color Maps" },
-      { type: "imageconvertions_colortobinary", label: "Color to Binary" }
+      { type: "imageconvertions_colortobinary", label: "Color to Binary" },
+      { type: "imageconvertions_bgrtohsv", label: "BGR to HSV" },
+      { type: "imageconvertions_hsvtobgr", label: "HSV to BGR" },
+      { type: "imageconvertions_bgrtolab", label: "BGR to LAB" },
+      { type: "imageconvertions_labtobgr", label: "LAB to BGR" },
+      { type: "imageconvertions_bgrtoycrcb", label: "BGR to YCrCb" },
+      { type: "imageconvertions_ycrcbtobgr", label: "YCrCb to BGR" }
     ]
   },
   {

--- a/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
@@ -87,5 +87,53 @@ export const conversionsBlocks = [
     nextStatement: null,
     style: "conversions_style",
     tooltip: "Convert colored (RGB) image to binary with adjustable threshold - Applies a binary threshold to a colored image, converting it to black and white. You can choose between 'Threshold Binary' (pixels above the threshold become white) and 'Threshold Binary Inv' (pixels above the threshold become black). Adjust the threshold value to control which pixels are considered foreground (white) or background (black), and set the max value for the output binary image.",
+  },
+  {
+    type: "imageconvertions_bgrtohsv",
+    message0: "Convert BGR to HSV",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts an image from BGR to HSV color space (separates color from brightness)."
+  },
+  {
+    type: "imageconvertions_hsvtobgr",
+    message0: "Convert HSV to BGR",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts an image from HSV back to BGR color space."
+  },
+  {
+    type: "imageconvertions_bgrtolab",
+    message0: "Convert BGR to LAB",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts BGR to LAB color space (approximates human vision)."
+  },
+  {
+    type: "imageconvertions_labtobgr",
+    message0: "Convert LAB to BGR",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts LAB back to BGR color space."
+  },
+  {
+    type: "imageconvertions_bgrtoycrcb",
+    message0: "Convert BGR to YCrCb",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts BGR to YCrCb color space (separates luma from chroma)."
+  },
+  {
+    type: "imageconvertions_ycrcbtobgr",
+    message0: "Convert YCrCb to BGR",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Converts YCrCb back to BGR color space."
   }
 ];


### PR DESCRIPTION
## Description
Added six new color space conversion operators strictly following the existing operator pattern to support Hue-Saturation-Value (HSV), CIELAB (Lab), and Luma-Chroma (YCrCb) pipelines.
- **Backend Implementations**: Added `BgrToHsv`, `HsvToBgr`, `BgrToLab`, `LabToBgr`, `BgrToYcrcb`, and `YcrcbToBgr` to `app/operators/conversions/`. 
- **Graceful Error Handling**: Forward conversions correctly intercept 1-channel grayscale inputs, explicitly converting them to 3-channel BGR before applying the target transformation. Reverse conversions similarly shield downstream operators by guaranteeing a 3-channel output even if fed a grayscale image.
- **Frontend Implementations**: Added six new UI blocks (with no parameters) into the Conversions category (`categories.ts` and `conversions.blocks.ts`), providing clear and accurate tooltips for the utility of each color space.
Fixes #62
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
## How Has This Been Tested?
Verified in both the local React frontend and FastAPI backend by adding the respective forward and reverse blocks into an active pipeline.
- **Round-Trip Fidelity**: Confirmed that sequentially combining `Read Image` -> `BGR to HSV` -> `HSV to BGR` returned an output visually identical to the original unaffected image. Verified the exact same behavior sequentially across `Lab` and `YCrCb`.
- **Visual Differences**: Directly viewing the output of the forward conversions correctly rendered fundamentally distinct visual data (e.g. separated luminance paths).
- **Graceful Grayscale Validation**: Placed a `Gray Image` block immediately before forward and reverse pipeline executions to confirm lack of assertion crashes and correct automatic color-expansion behavior.
- **Automated Checks**: Verified clean passes across backend `pytest`, backend `ruff`, and frontend `eslint`.
*Note for manual reviewers: In OpenCV, HSV hue ranges are represented as `[0,179]` rather than `[0,359]` to fit inside an 8-bit array. This is completely standard but explains why pure HSV blocks look visually "abnormal" when parsed as native BGR arrays by the viewer.*
- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
