### PR TITLE
Added the histogram equalization operator

### DIFF
--- a/imagelab-backend/app/operators/conversions/histogram_equalization.py
+++ b/imagelab-backend/app/operators/conversions/histogram_equalization.py
@@ -1,0 +1,34 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class HistogramEqualization(BaseOperator):
+    """
+    Enhances image contrast using histogram equalization.
+    Works for both grayscale and color images.
+    No parameters required.
+    """
+
+    def compute(self, image: np.ndarray) -> np.ndarray:
+
+        if image is None:
+            return image
+
+        # Grayscale image
+        if len(image.shape) == 2:
+            return cv2.equalizeHist(image)
+
+        # Color image (BGR)
+        if len(image.shape) == 3 and image.shape[2] == 3:
+            # Convert to YCrCb to preserve color fidelity
+            ycrcb = cv2.cvtColor(image, cv2.COLOR_BGR2YCrCb)
+
+            # Equalize only the luminance channel
+            ycrcb[:, :, 0] = cv2.equalizeHist(ycrcb[:, :, 0])
+
+            # Convert back to BGR
+            return cv2.cvtColor(ycrcb, cv2.COLOR_YCrCb2BGR)
+
+        return image

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -17,6 +17,7 @@ from app.operators.conversions.color_maps import ColorMaps
 from app.operators.conversions.color_to_binary import ColorToBinary
 from app.operators.conversions.gray_image import GrayImage
 from app.operators.conversions.gray_to_binary import GrayToBinary
+from app.operators.conversions.histogram_equalization import HistogramEqualization
 from app.operators.conversions.hsv_to_bgr import HsvToBgr
 from app.operators.conversions.invert_image import InvertImage
 from app.operators.conversions.lab_to_bgr import LabToBgr
@@ -76,6 +77,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "imageconvertions_graytobinary": GrayToBinary,
     "imageconvertions_colormaps": ColorMaps,
     "imageconvertions_colortobinary": ColorToBinary,
+    "imageconvertions_histogramequalization": HistogramEqualization,
     "imageconvertions_bgrtohsv": BgrToHsv,
     "imageconvertions_hsvtobgr": HsvToBgr,
     "imageconvertions_bgrtolab": BgrToLab,

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -44,6 +44,7 @@ export const categories: CategoryInfo[] = [
       { type: "imageconvertions_graytobinary", label: "Gray to Binary" },
       { type: "imageconvertions_colormaps", label: "Color Maps" },
       { type: "imageconvertions_colortobinary", label: "Color to Binary" },
+      { type: "imageconvertions_histogramequalization", label: "Histogram Equalization" },
       { type: "imageconvertions_bgrtohsv", label: "BGR to HSV" },
       { type: "imageconvertions_hsvtobgr", label: "HSV to BGR" },
       { type: "imageconvertions_bgrtolab", label: "BGR to LAB" },

--- a/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
@@ -130,6 +130,14 @@ export const conversionsBlocks = [
       "Convert colored (RGB) image to binary with adjustable threshold - Applies a binary threshold to a colored image, converting it to black and white. You can choose between 'Threshold Binary' (pixels above the threshold become white) and 'Threshold Binary Inv' (pixels above the threshold become black). Adjust the threshold value to control which pixels are considered foreground (white) or background (black), and set the max value for the output binary image.",
   },
   {
+    type: "imageconvertions_histogramequalization",
+    message0: "Enhance contrast using histogram equalization",
+    previousStatement: null,
+    nextStatement: null,
+    style: "conversions_style",
+    tooltip: "Automatically improves image contrast using histogram equalization",
+  },
+  {
     type: "imageconvertions_bgrtohsv",
     message0: "Convert BGR to HSV",
     previousStatement: null,


### PR DESCRIPTION
## Description

Implemented the **Histogram Equalization operator for both backend and frontend**.

On the backend, a new HistogramEqualization operator was added under the conversions module, following the existing BaseOperator pattern. The operator applies cv2.equalizeHist() for grayscale images and, for color images, performs equalization on the luminance (Y) channel in YCrCb space to preserve color fidelity. It requires no parameters and has been registered in registry.py to integrate with the processing pipeline.

On the frontend, a corresponding Blockly block was added under the Conversions category with no parameter fields, fully integrated into the existing pipeline flow.

The implementation has been validated using standard and low-contrast grayscale and color images, confirming improved contrast and compatibility with downstream operators.

Fixes #41 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.
- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

<img width="1440" height="848" alt="Screenshot 2026-02-26 at 11 05 39 AM" src="https://github.com/user-attachments/assets/c6f7957b-1983-4576-bede-a22465d99d49" />
<img width="1440" height="858" alt="Screenshot 2026-02-26 at 11 07 38 AM" src="https://github.com/user-attachments/assets/e346549e-8d6d-4b51-8cbc-182b682b3e5b" />
<img width="1435" height="851" alt="Screenshot 2026-02-26 at 11 15 14 AM" src="https://github.com/user-attachments/assets/f3ae976a-3552-47b1-8a22-0defb98ac9ee" />
<img width="1435" height="853" alt="Screenshot 2026-02-26 at 11 23 35 AM" src="https://github.com/user-attachments/assets/087b4624-9170-43ba-b070-667a7f2a5566" />

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
