### PR TITLE
feat: add real-time pipeline step counter and block statistics (#60)

### DIFF
--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -25,6 +25,10 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     setExecuting,
     setError,
     reset,
+    blockCount,
+    uniqueBlockTypes,
+    categoryCounts,
+    complexity,
   } = usePipelineStore();
 
   const handleNew = () => {
@@ -126,6 +130,41 @@ export default function Toolbar({ workspace }: ToolbarProps) {
         {isExecuting ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
         {isExecuting ? "Running..." : "Run"}
       </button>
+
+      {/* Spacer to push stats to the right */}
+      <div className="flex-1" />
+
+      {/* Live Statistics Display */}
+      {blockCount > 0 && (
+        <div className="relative group cursor-help px-2 flex items-center h-full border-l border-gray-100 ml-2">
+          <div className="flex flex-col items-end leading-tight">
+            <span className="font-semibold text-xs text-gray-700">{blockCount} {blockCount === 1 ? 'block' : 'blocks'}</span>
+            <span className={`text-[10px] uppercase font-bold tracking-wide ${complexity === 'High' ? 'text-red-500' :
+                complexity === 'Medium' ? 'text-orange-500' : 'text-green-500'
+              }`}>
+              {complexity} Complexity
+            </span>
+          </div>
+
+          <div className="absolute right-0 top-full mt-2 w-56 bg-white border border-gray-200 rounded-lg shadow-xl p-3 z-50 opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity duration-200">
+            <div className="font-semibold text-xs text-gray-800 mb-2 border-b border-gray-100 pb-1.5 uppercase tracking-wider">
+              Block Breakdown
+            </div>
+            <div className="space-y-1.5">
+              {Object.entries(categoryCounts).sort((a, b) => b[1] - a[1]).map(([cat, count]) => (
+                <div key={cat} className="flex justify-between items-center text-xs text-gray-600">
+                  <span className="truncate pr-2">{cat}</span>
+                  <span className="font-medium bg-gray-100 px-1.5 py-0.5 rounded text-[10px]">{count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-2.5 pt-2 border-t border-gray-100 flex justify-between items-center text-gray-500 text-[10px] uppercase">
+              <span>Unique Types</span>
+              <span className="font-bold text-gray-700 bg-gray-100 px-1.5 py-0.5 rounded">{uniqueBlockTypes}</span>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
+++ b/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
@@ -13,6 +13,7 @@ export function useBlocklyWorkspace() {
   const workspaceRef = useRef<Blockly.WorkspaceSvg | null>(null);
   const [workspace, setWorkspace] = useState<Blockly.WorkspaceSvg | null>(null);
   const setSelectedBlock = usePipelineStore((s) => s.setSelectedBlock);
+  const updateBlockStats = usePipelineStore((s) => s.updateBlockStats);
 
   const initWorkspace = useCallback(() => {
     if (!containerRef.current || workspaceRef.current) return;
@@ -66,13 +67,22 @@ export function useBlocklyWorkspace() {
           block.dispose(false);
         }
       }
+
+      // Update stats when blocks are created, deleted, or changed (which might alter their active state but mainly create/delete impact counts)
+      if (
+        event.type === Blockly.Events.BLOCK_CREATE ||
+        event.type === Blockly.Events.BLOCK_DELETE
+      ) {
+        updateBlockStats(ws);
+      }
     });
 
     new WorkspaceSearch(ws).init();
 
     workspaceRef.current = ws;
     setWorkspace(ws);
-  }, [setSelectedBlock]);
+    updateBlockStats(ws); // Initial stats calculation if any blocks loaded
+  }, [setSelectedBlock, updateBlockStats]);
 
   useEffect(() => {
     initWorkspace();

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import * as Blockly from 'blockly';
+import { categories } from '../blocks/categories';
 
 interface PipelineState {
   originalImage: string | null;
@@ -9,15 +11,29 @@ interface PipelineState {
   errorStep: number | null;
   selectedBlockType: string | null;
   selectedBlockTooltip: string | null;
+
+  // Statistics
+  blockCount: number;
+  uniqueBlockTypes: number;
+  categoryCounts: Record<string, number>;
+  complexity: 'Low' | 'Medium' | 'High';
   setOriginalImage: (image: string, format: string) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
   setError: (error: string | null, step?: number | null) => void;
   setSelectedBlock: (type: string | null, tooltip: string | null) => void;
+  updateBlockStats: (workspace: Blockly.WorkspaceSvg) => void;
   reset: () => void;
   clearImage: () => void;
   _imageResetFn: (() => void) | null;
   registerImageReset: (fn: () => void) => void;
+}
+
+function calculateComplexity(blocks: number, unique: number): 'Low' | 'Medium' | 'High' {
+  if (blocks === 0) return 'Low';
+  if (blocks > 10 || unique > 5) return 'High';
+  if (blocks > 3 || unique > 2) return 'Medium';
+  return 'Low';
 }
 
 export const usePipelineStore = create<PipelineState>((set) => ({
@@ -29,12 +45,15 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   errorStep: null,
   selectedBlockType: null,
   selectedBlockTooltip: null,
+  blockCount: 0,
+  uniqueBlockTypes: 0,
+  categoryCounts: {},
+  complexity: 'Low',
   setOriginalImage: (image, format) => set({ originalImage: image, imageFormat: format, processedImage: null, error: null }),
   setProcessedImage: (image) => set({ processedImage: image, error: null, errorStep: null }),
   setExecuting: (executing) => set({ isExecuting: executing }),
   setError: (error, step = null) => set({ error, errorStep: step }),
   setSelectedBlock: (type, tooltip) => set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
-  reset: () => set({ originalImage: null, imageFormat: 'png', processedImage: null, isExecuting: false, error: null, errorStep: null, selectedBlockType: null, selectedBlockTooltip: null }),
   _imageResetFn: null as (() => void) | null,
   registerImageReset: (fn) => set({ _imageResetFn: fn }),
   clearImage: () => {
@@ -42,5 +61,44 @@ export const usePipelineStore = create<PipelineState>((set) => ({
     if (state._imageResetFn) state._imageResetFn();
     set({ originalImage: null, processedImage: null, error: null, errorStep: null });
   },
+  updateBlockStats: (workspace) => {
+    const blocks = workspace.getAllBlocks(false);
 
+    const typeToCategory: Record<string, string> = {};
+    categories.forEach(cat => {
+      cat.blocks.forEach(b => {
+        typeToCategory[b.type] = cat.name;
+      });
+    });
+
+    const uniqueTypes = new Set<string>();
+    const counts: Record<string, number> = {};
+
+    blocks.forEach(block => {
+      uniqueTypes.add(block.type);
+      const cat = typeToCategory[block.type] || 'Unknown';
+      counts[cat] = (counts[cat] || 0) + 1;
+    });
+
+    set({
+      blockCount: blocks.length,
+      uniqueBlockTypes: uniqueTypes.size,
+      categoryCounts: counts,
+      complexity: calculateComplexity(blocks.length, uniqueTypes.size)
+    });
+  },
+  reset: () => set({
+    originalImage: null,
+    imageFormat: 'png',
+    processedImage: null,
+    isExecuting: false,
+    error: null,
+    errorStep: null,
+    selectedBlockType: null,
+    selectedBlockTooltip: null,
+    blockCount: 0,
+    uniqueBlockTypes: 0,
+    categoryCounts: {},
+    complexity: 'Low'
+  }),
 }));


### PR DESCRIPTION
## Description

Adds a live, real-time Pipeline Step Counter and Block Statistics breakdown to the Editor Toolbar to satisfy Issue #60.

- **State Hooking**: Upgraded `pipelineStore.ts` to compute detailed metrics from any initialized Blockly workspace (total counts, unique types, category aggregations from `categories.ts`, and a relative complexity metric).
- **Fast Event Observers**: Added granular listeners inside `useBlocklyWorkspace.ts` tracking `Blockly.Events.BLOCK_CREATE` and `BLOCK_DELETE` to trigger lightning-fast React state updates upon canvas alterations without heavy polling.
- **Hover Stats Dashboard**: Extended `Toolbar.tsx` with a clean, un-intrusive metadata block reflecting the active `blockCount` and `complexity`. Simply hovering over it opens a beautifully separated tooltip itemizing exactly how many "Filtering", "Basic", or "Geometric" blocks compile the working solution alongside uniquely stacked types.

Fixes #60

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] **Zero State**: Verified that clearing the workspace cleanly unmounts the statistics display ("0 blocks" gracefully hidden).
- [x] **Creation and Deletion**: Dragged blocks across categories on/off the canvas and confirmed the block counter increments/decrements synchronously.
- [x] **Complexity Algorithm**: Verified behavior bounds transitions (`Low` at <= 3 blocks, `Medium`, and `High` at > 10 blocks / > 5 unique types).
- [x] **Linting Integrity**: Executed `npm run lint` and `npm run build` ensuring Vite compilation succeeds cleanly against the state and TypeScript constraints.

