### PR TITLE
Added Keyboard Shortcuts for Common Actions #58

### DIFF
--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -3,10 +3,17 @@ import { FilePlus, Download, Undo2, Redo2, Play, Loader2 } from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 
 interface ToolbarProps {
   workspace: Blockly.WorkspaceSvg | null;
 }
+
+// Detect macOS to show Cmd vs Ctrl in tooltips
+const isMac =
+  typeof navigator !== "undefined" &&
+  /mac/i.test(navigator.platform || navigator.userAgent);
+const mod = isMac ? "⌘" : "Ctrl+";
 
 export default function Toolbar({ workspace }: ToolbarProps) {
   const {
@@ -72,6 +79,15 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     }
   };
 
+  // Register global keyboard shortcuts
+  useKeyboardShortcuts({
+    onRun: handleRun,
+    onDownload: handleDownload,
+    onUndo: handleUndo,
+    onRedo: handleRedo,
+    workspace,
+  });
+
   const iconBtn =
     "p-1.5 rounded hover:bg-gray-100 text-gray-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors";
   const separator = "w-px h-5 bg-gray-300 mx-1";
@@ -85,17 +101,17 @@ export default function Toolbar({ workspace }: ToolbarProps) {
         onClick={handleDownload}
         disabled={!processedImage}
         className={iconBtn}
-        title="Download"
+        title={`Download (${mod}S)`}
       >
         <Download size={18} />
       </button>
 
       <div className={separator} />
 
-      <button onClick={handleUndo} className={iconBtn} title="Undo">
+      <button onClick={handleUndo} className={iconBtn} title={`Undo (${mod}Z)`}>
         <Undo2 size={18} />
       </button>
-      <button onClick={handleRedo} className={iconBtn} title="Redo">
+      <button onClick={handleRedo} className={iconBtn} title={`Redo (${mod}Y or ${mod}⇧Z)`}>
         <Redo2 size={18} />
       </button>
 

--- a/imagelab-frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/imagelab-frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import * as Blockly from "blockly";
+
+interface ShortcutHandlers {
+  onRun: () => void;
+  onDownload: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  workspace: Blockly.WorkspaceSvg | null;
+}
+
+function isTypingInBlockly(): boolean {
+  const active = document.activeElement;
+  if (!active) return false;
+  const tag = active.tagName.toLowerCase();
+  // Blockly uses <input> and <textarea> for field editors
+  if (tag === "input" || tag === "textarea") return true;
+  // contenteditable divs used by some Blockly fields
+  if ((active as HTMLElement).isContentEditable) return true;
+  return false;
+}
+
+export function useKeyboardShortcuts({
+  onRun,
+  onDownload,
+  onUndo,
+  onRedo,
+  workspace,
+}: ShortcutHandlers) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const meta = e.ctrlKey || e.metaKey;
+
+      // Delete/Backspace: remove selected Blockly block (not when typing)
+      if ((e.key === "Delete" || e.key === "Backspace") && !isTypingInBlockly()) {
+        if (workspace) {
+          const selected = Blockly.common.getSelected();
+          if (selected && selected instanceof Blockly.BlockSvg) {
+            e.preventDefault();
+            selected.dispose(true, true);
+            return;
+          }
+        }
+      }
+
+      if (!meta) return;
+
+      switch (e.key) {
+        case "Enter":
+          e.preventDefault();
+          onRun();
+          break;
+        case "s":
+        case "S":
+          e.preventDefault();
+          onDownload();
+          break;
+        case "z":
+        case "Z":
+          if (!isTypingInBlockly()) {
+            e.preventDefault();
+            if (e.shiftKey) {
+              onRedo();
+            } else {
+              onUndo();
+            }
+          }
+          break;
+        case "y":
+        case "Y":
+          if (!isTypingInBlockly()) {
+            e.preventDefault();
+            onRedo();
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onRun, onDownload, onUndo, onRedo, workspace]);
+}


### PR DESCRIPTION
# 🚀 Add Global Keyboard Shortcuts for Common Actions (#58)

## 📌 Overview
This PR introduces global keyboard shortcuts for frequently used actions in ImageLab to improve workflow efficiency and usability. The shortcuts work regardless of component focus (except when typing in input fields) and enhance the editor-like experience for users.

The implementation supports both **Ctrl (Windows/Linux)** and **Cmd (macOS)** modifier keys.

---

## ✅ What’s Included

### 🔹 Global Shortcut Handler
A centralized keyboard event listener has been implemented to handle shortcuts consistently across the application.

### 🔹 Supported Shortcuts

| Action | Windows/Linux | macOS |
|--------|--------------|--------|
| Run Pipeline | `Ctrl + Enter` | `Cmd + Enter` |
| Download Image | `Ctrl + S` | `Cmd + S` |
| Undo | `Ctrl + Z` | `Cmd + Z` |
| Redo | `Ctrl + Y` / `Ctrl + Shift + Z` | `Cmd + Shift + Z` |
| Delete Selected Block | `Delete` / `Backspace` | `Delete` / `Backspace` |

---

## 🛠 Implementation Details

- Prevented default browser behavior for `Ctrl/Cmd + S`
- Integrated undo/redo with Blockly APIs
- Used Blockly selected block API for Delete functionality
- Added input field detection to prevent shortcut interference while typing
- Ensured shortcuts work regardless of which component has focus
- Updated toolbar button tooltips to display corresponding shortcut hints

---

## 🎯 Acceptance Criteria Coverage

- ✔ Global keyboard shortcut handler implemented  
- ✔ Ctrl/Cmd modifier supported  
- ✔ Prevented browser default save behavior  
- ✔ Undo/Redo integrated correctly  
- ✔ Delete removes selected block  
- ✔ No interference with text/number input fields  
- ✔ Shortcut hints added to toolbar tooltips  

---

## 💡 Why This Matters

These shortcuts significantly improve productivity for users building and testing pipelines. The behavior aligns ImageLab with standard editor-style applications, making it more intuitive and efficient.