### PR TITLE
Feature: Implemented crop operator

### DIFF
--- a/imagelab-backend/app/operators/geometric/crop_image.py
+++ b/imagelab-backend/app/operators/geometric/crop_image.py
@@ -1,0 +1,29 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class CropImage(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        height, width = image.shape[:2]
+
+        # Get cropping coordinates from parameters with defaults
+        x1 = int(self.params.get("x1", 0))
+        y1 = int(self.params.get("y1", 0))
+        x2 = int(self.params.get("x2", image.shape[1]))
+        y2 = int(self.params.get("y2", image.shape[0]))
+
+        # Clamp to boundaries (Requirement: No out-of-bounds)
+        x1 = max(0, min(x1, width))
+        y1 = max(0, min(y1, height))
+        x2 = max(0, min(x2, width))
+        y2 = max(0, min(y2, height))
+
+        # If the coordinates are invalid return the original image
+        if x1 >= x2 or y1 >= y2:
+            return image
+
+        # Image slicing in OpenCV is image[y1:y2, x1:x2]
+        cropped_image = image[y1:y2, x1:x2]
+        return cropped_image

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -26,6 +26,7 @@ from app.operators.geometric.affine_image import AffineImage
 from app.operators.geometric.reflect_image import ReflectImage
 from app.operators.geometric.rotate_image import RotateImage
 from app.operators.geometric.scale_image import ScaleImage
+from app.operators.geometric.crop_image import CropImage
 from app.operators.sobel_derivatives.scharr_derivative import ScharrDerivative
 from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
 from app.operators.thresholding.adaptive_threshold import AdaptiveThreshold
@@ -44,6 +45,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "geometric_rotateimage": RotateImage,
     "geometric_scaleimage": ScaleImage,
     "geometric_affineimage": AffineImage,
+    "geometric_cropimage": CropImage,
     # Conversions
     "imageconvertions_grayimage": GrayImage,
     "imageconvertions_channelsplit": ChannelSplit,

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -26,6 +26,7 @@ export const categories: CategoryInfo[] = [
     colour: "#64B5F6",
     blocks: [
       { type: "geometric_reflectimage", label: "Reflect Image" },
+      { type: "geometric_cropimage", label: "Crop Image" },
       { type: "geometric_rotateimage", label: "Rotate Image" },
       { type: "geometric_affineimage", label: "Affine Transform" },
       { type: "geometric_scaleimage", label: "Scale Image" }

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -39,6 +39,20 @@ export const geometricBlocks = [
     tooltip: "Scales the image by the given factors - Resizes the image by scaling factors along the X and Y axes. A factor greater than 1 enlarges the image, while a factor between 0 and 1 reduces its size. This transformation is useful for resizing images for display, analysis, or to fit specific dimensions."
   },
   {
+    type: "geometric_cropimage",
+    message0: "Crop image to coordinates x1 %1 y1 %2 x2 %3 and y2 %4",
+    args0: [
+      { type: "field_number", name: "x1", value: 0, min: 0 },
+      { type: "field_number", name: "y1", value: 0, min: 0 },
+      { type: "field_number", name: "x2", value: 0, min: 0 },
+      { type: "field_number", name: "y2", value: 0, min: 0 }
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "geometric_style",
+    tooltip: "Crops the image to the specified coordinates"
+  },
+  {
     type: "geometric_affineimage",
     message0: "Apply affine transformation",
     previousStatement: null,


### PR DESCRIPTION
## Description
Crops an image to a rectangular region defined by two corner points. Specify the top-left corner (x1, y1) and bottom-right corner (x2, y2) in pixel coordinates. Coordinates are automatically clamped to image boundaries. If invalid coordinates are provided (x1 >= x2 or y1 >= y2), the original image is returned unchanged.

Brief summary of the changes. Reference any related issues.

Fixes #52

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Manually tested
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
For default coordinates:
<img width="1280" height="570" alt="image" src="https://github.com/user-attachments/assets/e9f99ebb-79d9-4720-b620-0b35534e4995" />

For valid coordinates:
<img width="1280" height="573" alt="image" src="https://github.com/user-attachments/assets/ba61cd15-0a30-4e93-a0ff-1da327b25e75" />

For invalid coordinates:
<img width="1280" height="569" alt="image" src="https://github.com/user-attachments/assets/f19fdc8c-3928-4861-9b74-3d0dc25d9147" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally
