### PR TITLE
feature: add Canny edge detection operator

### DIFF
--- a/imagelab-backend/app/operators/filtering/canny_edge.py
+++ b/imagelab-backend/app/operators/filtering/canny_edge.py
@@ -1,0 +1,58 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class CannyEdge(BaseOperator):
+    """Applies Canny edge detection to an image.
+
+    Color (BGR) images are converted to grayscale before processing.
+    BGRA images have the alpha channel removed. Already-grayscale
+    (single-channel 2D or shape (H, W, 1)) images are passed directly
+    to the detector. The output is always a 3-channel BGR image with
+    white edges on a black background, suitable for downstream pipeline
+    operators.
+
+    Params:
+        threshold1 (float): Lower hysteresis threshold (default: 100).
+            Clamped to >= 0. Swapped with threshold2 if greater.
+            Practical range for uint8 images is [0, 255].
+        threshold2 (float): Upper hysteresis threshold (default: 200).
+            Clamped to >= 0. Must be >= threshold1.
+            Practical range for uint8 images is [0, 255].
+
+    Note:
+        ``apertureSize`` (Sobel kernel size) and ``L2gradient`` are fixed
+        at OpenCV defaults (3 and False, respectively) and are not
+        currently exposed as parameters.
+    """
+
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        threshold1 = max(0.0, float(self.params.get("threshold1", 100)))
+        threshold2 = max(0.0, float(self.params.get("threshold2", 200)))
+
+        # Enforce hysteresis ordering
+        if threshold1 > threshold2:
+            threshold1, threshold2 = threshold2, threshold1
+
+        if len(image.shape) == 3:
+            channels = image.shape[2]
+            if channels == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            elif channels == 3:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            elif channels == 1:
+                image = image[:, :, 0]
+            else:
+                raise ValueError(f"Unsupported number of channels: {channels}. Expected 1, 3, or 4.")
+
+        # cv2.Canny requires uint8 input
+        if image.dtype != np.uint8:
+            if np.issubdtype(image.dtype, np.floating) and image.max() <= 1.0:
+                image = image * 255.0
+            image = np.clip(image, 0, 255).astype(np.uint8)
+
+        edges = cv2.Canny(image, threshold1, threshold2)
+
+        return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -28,6 +28,7 @@ from app.operators.drawing.draw_rectangle import DrawRectangle
 from app.operators.drawing.draw_text import DrawText
 from app.operators.filtering.bilateral_filter import BilateralFilter
 from app.operators.filtering.box_filter import BoxFilter
+from app.operators.filtering.canny_edge import CannyEdge
 from app.operators.filtering.contour_detection import ContourDetection
 from app.operators.filtering.dilation import Dilation
 from app.operators.filtering.erosion import Erosion
@@ -99,6 +100,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "filtering_erosion": Erosion,
     "filtering_dilation": Dilation,
     "filtering_morphological": Morphological,
+    "filtering_cannyedge": CannyEdge,
     # Augmentation
     "augmentation_gaussiannoise": GaussianNoise,
     "augmentation_saltpeppernoise": SaltPepperNoise,

--- a/imagelab-backend/tests/test_canny_edge.py
+++ b/imagelab-backend/tests/test_canny_edge.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from app.operators.filtering.canny_edge import CannyEdge
+
+
+def make_bgr(h: int = 64, w: int = 64) -> np.ndarray:
+    return np.random.randint(0, 256, (h, w, 3), dtype=np.uint8)
+
+
+class TestCannyEdgeOutputShape:
+    def test_bgr_input(self):
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(make_bgr())
+        assert out.shape == (64, 64, 3)
+
+    def test_grayscale_2d_input(self):
+        gray = np.random.randint(0, 256, (64, 64), dtype=np.uint8)
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(gray)
+        assert out.shape == (64, 64, 3)
+
+    def test_grayscale_hwc1_input(self):
+        gray = np.random.randint(0, 256, (64, 64, 1), dtype=np.uint8)
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(gray)
+        assert out.shape == (64, 64, 3)
+
+    def test_bgra_input(self):
+        bgra = np.random.randint(0, 256, (64, 64, 4), dtype=np.uint8)
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(bgra)
+        assert out.shape == (64, 64, 3)
+
+
+class TestCannyEdgeThresholdSwap:
+    def test_swapped_thresholds_produce_same_result(self):
+        img = make_bgr()
+        op_normal = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        op_swapped = CannyEdge(params={"threshold1": 150, "threshold2": 50})
+        np.testing.assert_array_equal(op_normal.compute(img), op_swapped.compute(img))
+
+
+class TestCannyEdgeFloatInput:
+    def test_normalized_float_not_all_black(self):
+        img = np.random.rand(64, 64, 3).astype(np.float32)
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(img)
+        assert out.shape == (64, 64, 3)
+
+    def test_uint16_input(self):
+        img = np.random.randint(0, 65536, (64, 64, 3), dtype=np.uint16)
+        op = CannyEdge(params={"threshold1": 50, "threshold2": 150})
+        out = op.compute(img)
+        assert out.shape == (64, 64, 3)
+
+
+class TestCannyEdgeInvalidInput:
+    def test_unsupported_channel_count_raises(self):
+        img = np.random.randint(0, 256, (64, 64, 2), dtype=np.uint8)
+        op = CannyEdge(params={})
+        with pytest.raises(ValueError, match="Unsupported number of channels"):
+            op.compute(img)

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -99,6 +99,7 @@ export const categories: CategoryInfo[] = [
       { type: "filtering_erosion", label: "Erosion" },
       { type: "filtering_dilation", label: "Dilation" },
       { type: "filtering_morphological", label: "Morphological" },
+      { type: "filtering_cannyedge", label: "Canny Edge Detection" },
       { type: "filtering_gaborfilter", label: "Gabor Filter" },
       { type: "filtering_contourdetection", label: "Contour Detection" },
       { type: "filtering_cannyedge", label: "Canny Edge Detection" },

--- a/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
@@ -167,4 +167,22 @@ export const filteringBlocks = [
     style: "filtering_style",
     tooltip: "Detects contours on an image and renders them over the original graphic.",
   },
+  {
+    type: "filtering_cannyedge",
+    message0: "Canny Edge Detection %1 Threshold 1 %2 %3 Threshold 2 %4",
+    args0: [
+      { type: "input_dummy" },
+      { type: "field_number", name: "threshold1", value: 100, min: 0, max: 500 },
+      { type: "input_dummy" },
+      { type: "field_number", name: "threshold2", value: 200, min: 0, max: 500 },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "filtering_style",
+    tooltip:
+      "Applies Canny edge detection - A multi-stage algorithm that detects a wide range of edges in images. " +
+      "Pixels with gradient magnitude above Threshold 2 are strong edges, below Threshold 1 are discarded, " +
+      "and those in between are kept only if connected to a strong edge. Color images are automatically " +
+      "converted to grayscale. If Threshold 1 is set higher than Threshold 2, the values are automatically swapped.",
+  },
 ];


### PR DESCRIPTION
## Description

Implements the Canny edge detection operator for ImageLab. Adds a new backend operator that accepts two threshold parameters (threshold1, threshold2) for hysteresis thresholding and handles color images by converting to grayscale internally before applying cv2.Canny(). Also adds the corresponding Blockly block to the frontend filtering category.

Fixes #40 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Manually tested end to end by building a pipeline with Read Image → Canny Edge Detection and running it in the preview pane. The processed output correctly shows white edges on a black background for a color input image.
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 
<img width="1400" height="754" alt="Screenshot 2026-02-27 at 4 10 35 PM" src="https://github.com/user-attachments/assets/5c6af127-1ba1-42ee-a012-09242cf93205" />

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally