### PR TITLE
feature: add search bar to filter blocks in sidebar

### DIFF
--- a/imagelab-frontend/src/components/Sidebar/CategorySection.tsx
+++ b/imagelab-frontend/src/components/Sidebar/CategorySection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import * as Blockly from "blockly";
 import {
   ChevronRight,
@@ -50,9 +50,12 @@ export default function CategorySection({
   const Icon = iconMap[category.icon];
 
   const isSearching = searchQuery.trim().length > 0;
-  const filteredBlocks = isSearching
-    ? category.blocks.filter((b) => b.label.toLowerCase().includes(searchQuery.toLowerCase()))
-    : category.blocks;
+
+  const filteredBlocks = useMemo(() => {
+    if (!isSearching) return category.blocks;
+    const lowerQuery = searchQuery.toLowerCase();
+    return category.blocks.filter((b) => b.label.toLowerCase().includes(lowerQuery));
+  }, [isSearching, searchQuery, category.blocks]);
 
   const effectiveOpen = isSearching ? filteredBlocks.length > 0 : isOpen;
 
@@ -61,13 +64,17 @@ export default function CategorySection({
   return (
     <div className="border-b border-gray-200">
       <button
-        onClick={() => setIsOpen(!effectiveOpen)}
-        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-gray-50 transition-colors"
+        type="button"
+        onClick={() => {
+          if (!isSearching) setIsOpen((prev) => !prev);
+        }}
+        aria-expanded={effectiveOpen}
+        className={`w-full flex items-center gap-2 px-3 py-2 hover:bg-gray-50 transition-colors ${isSearching ? "cursor-default" : ""}`}
       >
         {effectiveOpen ? (
-          <ChevronDown size={14} className="text-gray-400" />
+          <ChevronDown size={14} className={isSearching ? "text-gray-200" : "text-gray-400"} />
         ) : (
-          <ChevronRight size={14} className="text-gray-400" />
+          <ChevronRight size={14} className={isSearching ? "text-gray-200" : "text-gray-400"} />
         )}
         {Icon && <Icon size={16} color={category.colour} />}
         <span className="text-sm font-medium text-gray-700">{category.name}</span>

--- a/imagelab-frontend/src/components/Sidebar/Sidebar.tsx
+++ b/imagelab-frontend/src/components/Sidebar/Sidebar.tsx
@@ -42,8 +42,8 @@ export default function Sidebar({ workspace }: SidebarProps) {
   }, [workspace, tick]);
 
   return (
-    <div className="w-80 h-full bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0 flex flex-col">
-      <div className="px-3 py-2 border-b border-gray-200 flex flex-col gap-2">
+    <div className="w-80 h-full bg-white border-r border-gray-200 flex-shrink-0 flex flex-col">
+      <div className="flex-shrink-0 px-3 py-2 border-b border-gray-200 flex flex-col gap-2">
         <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Blocks</h2>
         <div className="relative">
           <Search
@@ -52,6 +52,7 @@ export default function Sidebar({ workspace }: SidebarProps) {
           />
           <input
             type="text"
+            aria-label="Search blocks"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search blocks..."
@@ -61,25 +62,28 @@ export default function Sidebar({ workspace }: SidebarProps) {
             <button
               type="button"
               title="Clear search"
+              aria-label="Clear search"
               onClick={() => setQuery("")}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
             >
-              <X size={12} />
+              <X size={12} aria-hidden="true" />
             </button>
           )}
         </div>
       </div>
-      {categories.map((category) => (
-        <CategorySection
-          key={category.name}
-          category={category}
-          workspace={workspace}
-          previews={previews}
-          disabledTypes={presentSingletons}
-          defaultOpen={category.name === "Basic"}
-          searchQuery={query}
-        />
-      ))}
+      <div className="overflow-y-auto flex-1">
+        {categories.map((category) => (
+          <CategorySection
+            key={category.name}
+            category={category}
+            workspace={workspace}
+            previews={previews}
+            disabledTypes={presentSingletons}
+            defaultOpen={category.name === "Basic"}
+            searchQuery={query}
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Adds a real-time search input to the block sidebar. As the user types, blocks are filtered across all categories instantly. Categories with no matching blocks are hidden, categories with matches auto expand, and the count badge updates to show matched vs total blocks (eg: 2/6). A clear button appears when there is an active query to reset the search.

Fixes #91 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Manually tested by searching for block names such as "gray", "blur", "edge", and "threshold" and verifying that categories filter correctly, auto-expand on match, and restore to default state when the search is cleared.
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 
<img width="1398" height="754" alt="blur" src="https://github.com/user-attachments/assets/dc49c8b5-5e5a-4ec0-a2c8-ddd595de7831" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally