### PR TITLE
test(geometric): add unit tests for scale, rotate, reflect, and affin…

### DIFF
--- a/imagelab-backend/tests/operators/geometric/test_affine_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_affine_image.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.affine_image import AffineImage
+
+
+def test_affine_preserves_shape() -> None:
+    img = np.zeros((240, 320), dtype=np.uint8)
+    out = AffineImage({}).compute(img)
+    assert out.shape == img.shape
+
+
+@pytest.mark.parametrize(
+    "src_xy,expected_xy",
+    [
+        ((10, 10), (60, 110)),
+        ((0, 0), (50, 100)),
+        ((100, 50), (150, 150)),
+        ((200, 10), (250, 110)),
+    ],
+)
+def test_affine_translates_sentinel_pixel_when_in_bounds(src_xy: tuple, expected_xy: tuple) -> None:
+    h, w = 300, 300
+    img = np.zeros((h, w), dtype=np.uint8)
+    x0, y0 = src_xy
+    x1, y1 = expected_xy
+    img[y0, x0] = 255
+    out = AffineImage({}).compute(img)
+    assert out[y1, x1] == 255
+    assert out.max() == 255
+
+
+@pytest.mark.parametrize(
+    "shape,src_xy",
+    [
+        ((120, 120), (80, 80)),
+        ((140, 60), (10, 10)),
+    ],
+)
+def test_affine_pixel_can_shift_out_of_bounds(shape: tuple, src_xy: tuple) -> None:
+    h, w = shape
+    img = np.zeros((h, w), dtype=np.uint8)
+    x0, y0 = src_xy
+    img[y0, x0] = 255
+    out = AffineImage({}).compute(img)
+    assert out.max() == 0

--- a/imagelab-backend/tests/operators/geometric/test_affine_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_affine_image.py
@@ -3,10 +3,13 @@ import pytest
 
 from app.operators.geometric.affine_image import AffineImage
 
+# explicit translation contract — all tests use the same dx/dy
+_DX, _DY = 50, 100
+
 
 def test_affine_preserves_shape() -> None:
     img = np.zeros((240, 320), dtype=np.uint8)
-    out = AffineImage({}).compute(img)
+    out = AffineImage({"dx": _DX, "dy": _DY}).compute(img)
     assert out.shape == img.shape
 
 
@@ -19,13 +22,14 @@ def test_affine_preserves_shape() -> None:
         ((200, 10), (250, 110)),
     ],
 )
-def test_affine_translates_sentinel_pixel_when_in_bounds(src_xy: tuple, expected_xy: tuple) -> None:
+def test_affine_translates_sentinel_pixel_when_in_bounds(src_xy: tuple[int, int], expected_xy: tuple[int, int]) -> None:
     h, w = 300, 300
     img = np.zeros((h, w), dtype=np.uint8)
     x0, y0 = src_xy
     x1, y1 = expected_xy
     img[y0, x0] = 255
-    out = AffineImage({}).compute(img)
+    out = AffineImage({"dx": _DX, "dy": _DY}).compute(img)
+    # integer translation hits exact grid points — no interpolation blending
     assert out[y1, x1] == 255
     assert out.max() == 255
 
@@ -37,10 +41,11 @@ def test_affine_translates_sentinel_pixel_when_in_bounds(src_xy: tuple, expected
         ((140, 60), (10, 10)),
     ],
 )
-def test_affine_pixel_can_shift_out_of_bounds(shape: tuple, src_xy: tuple) -> None:
+def test_affine_pixel_can_shift_out_of_bounds(shape: tuple[int, int], src_xy: tuple[int, int]) -> None:
     h, w = shape
     img = np.zeros((h, w), dtype=np.uint8)
     x0, y0 = src_xy
     img[y0, x0] = 255
-    out = AffineImage({}).compute(img)
+    out = AffineImage({"dx": _DX, "dy": _DY}).compute(img)
+    # AffineImage uses BORDER_CONSTANT(0); pixels shifted out of bounds become 0
     assert out.max() == 0

--- a/imagelab-backend/tests/operators/geometric/test_reflect_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_reflect_image.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.reflect_image import ReflectImage
+
+
+@pytest.mark.parametrize(
+    "flip_type,expected",
+    [
+        ("X", np.array([[3, 4, 5], [0, 1, 2]], dtype=np.uint8)),
+        ("Y", np.array([[2, 1, 0], [5, 4, 3]], dtype=np.uint8)),
+        ("Both", np.array([[5, 4, 3], [2, 1, 0]], dtype=np.uint8)),
+        ("UNKNOWN", np.array([[3, 4, 5], [0, 1, 2]], dtype=np.uint8)),
+    ],
+)
+def test_reflect_flip_modes(flip_type: str, expected: np.ndarray) -> None:
+    img = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.uint8)
+    out = ReflectImage({"type": flip_type}).compute(img)
+    assert np.array_equal(out, expected)
+
+
+def test_reflect_preserves_shape() -> None:
+    img = np.zeros((10, 20, 3), dtype=np.uint8)
+    out = ReflectImage({"type": "Y"}).compute(img)
+    assert out.shape == img.shape

--- a/imagelab-backend/tests/operators/geometric/test_rotate_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_rotate_image.py
@@ -25,7 +25,8 @@ def test_rotate_preserves_shape(angle: int) -> None:
 
 
 def test_rotate_0_is_identity() -> None:
-    img = np.random.randint(0, 256, size=(120, 160), dtype=np.uint8)
+    rng = np.random.default_rng(42)
+    img = rng.integers(0, 256, size=(120, 160), dtype=np.uint8)
     out = RotateImage({"angle": 0, "scale": 1.0}).compute(img)
     assert np.array_equal(out, img)
 
@@ -39,6 +40,6 @@ def test_rotate_moves_sentinel_pixel_to_expected_location(angle: int) -> None:
     out = RotateImage({"angle": angle, "scale": 1.0}).compute(img)
     cx, cy = w / 2, h / 2
     x1, y1 = _expected_rotated_xy(x0, y0, cx, cy, float(angle))
-    assert out.max() > 0
+    assert out.max() > 200, f"Sentinel pixel too dim after {angle}° rotation: max={out.max()}"
     y_got, x_got = np.unravel_index(out.argmax(), out.shape)
     assert (int(x_got), int(y_got)) == (x1, y1)

--- a/imagelab-backend/tests/operators/geometric/test_rotate_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_rotate_image.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.rotate_image import RotateImage
+
+
+def _expected_rotated_xy(x: int, y: int, cx: float, cy: float, angle_deg: float) -> tuple:
+    a = angle_deg % 360
+    if a == 0:
+        return (x, y)
+    if a == 90:
+        return (int(round(cx + (y - cy))), int(round(cy - (x - cx))))
+    if a == 180:
+        return (int(round(cx - (x - cx))), int(round(cy - (y - cy))))
+    if a == 270:
+        return (int(round(cx - (y - cy))), int(round(cy + (x - cx))))
+    raise ValueError("This helper is only for 0/90/180/270.")
+
+
+@pytest.mark.parametrize("angle", [0, 90, 180, 270])
+def test_rotate_preserves_shape(angle: int) -> None:
+    img = np.zeros((200, 200), dtype=np.uint8)
+    out = RotateImage({"angle": angle, "scale": 1.0}).compute(img)
+    assert out.shape == img.shape
+
+
+def test_rotate_0_is_identity() -> None:
+    img = np.random.randint(0, 256, size=(120, 160), dtype=np.uint8)
+    out = RotateImage({"angle": 0, "scale": 1.0}).compute(img)
+    assert np.array_equal(out, img)
+
+
+@pytest.mark.parametrize("angle", [90, 180, 270])
+def test_rotate_moves_sentinel_pixel_to_expected_location(angle: int) -> None:
+    h, w = 200, 200
+    img = np.zeros((h, w), dtype=np.uint8)
+    x0, y0 = 90, 80
+    img[y0, x0] = 255
+    out = RotateImage({"angle": angle, "scale": 1.0}).compute(img)
+    cx, cy = w / 2, h / 2
+    x1, y1 = _expected_rotated_xy(x0, y0, cx, cy, float(angle))
+    assert out.max() > 0
+    y_got, x_got = np.unravel_index(out.argmax(), out.shape)
+    assert (int(x_got), int(y_got)) == (x1, y1)

--- a/imagelab-backend/tests/operators/geometric/test_scale_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_scale_image.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.scale_image import ScaleImage
+
+
+@pytest.mark.parametrize(
+    "fx,fy,shape",
+    [
+        (1.0, 1.0, (10, 20, 3)),
+        (2.0, 2.0, (20, 40, 3)),
+        (0.5, 0.5, (5, 10, 3)),
+        (1.5, 2.0, (20, 30, 3)),
+        (0.25, 3.0, (30, 5, 3)),
+    ],
+)
+def test_scale_output_dimensions(fx: float, fy: float, shape: tuple) -> None:
+    img = np.zeros((10, 20, 3), dtype=np.uint8)
+    out = ScaleImage({"fx": fx, "fy": fy}).compute(img)
+    assert out.shape == shape
+
+
+def test_scale_identity_preserves_values() -> None:
+    img = np.full((8, 12, 3), 123, dtype=np.uint8)
+    out = ScaleImage({"fx": 1.0, "fy": 1.0}).compute(img)
+    assert out.shape == img.shape
+    assert np.array_equal(out, img)
+
+
+def test_scale_constant_image_stays_constant() -> None:
+    img = np.full((7, 9, 3), 7, dtype=np.uint8)
+    out = ScaleImage({"fx": 2.0, "fy": 3.0}).compute(img)
+    assert out.shape == (21, 18, 3)
+    assert np.all(out == 7)

--- a/imagelab-backend/tests/operators/geometric/test_scale_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_scale_image.py
@@ -14,7 +14,7 @@ from app.operators.geometric.scale_image import ScaleImage
         (0.25, 3.0, (30, 5, 3)),
     ],
 )
-def test_scale_output_dimensions(fx: float, fy: float, shape: tuple) -> None:
+def test_scale_output_dimensions(fx: float, fy: float, shape: tuple[int, int, int]) -> None:
     img = np.zeros((10, 20, 3), dtype=np.uint8)
     out = ScaleImage({"fx": fx, "fy": fy}).compute(img)
     assert out.shape == shape
@@ -32,3 +32,10 @@ def test_scale_constant_image_stays_constant() -> None:
     out = ScaleImage({"fx": 2.0, "fy": 3.0}).compute(img)
     assert out.shape == (21, 18, 3)
     assert np.all(out == 7)
+
+
+def test_scale_missing_parameters_uses_defaults() -> None:
+    # ScaleImage defaults: fx=1, fy=1 — output shape equals input shape
+    img = np.zeros((10, 20, 3), dtype=np.uint8)
+    out = ScaleImage({}).compute(img)
+    assert out.shape == img.shape


### PR DESCRIPTION
Adds pytest unit tests for the four geometric operators (ScaleImage, RotateImage, ReflectImage, AffineImage) that currently have no test coverage.

Fixes #47

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

cd imagelab-backend
uv run pytest -v

- [ ] Existing tests pass
- [x] New tests added
- [ ] Manual testing

Tests are organized under `tests/operators/geometric/` — one file per operator. Coverage includes:

- **Scale** — output dimensions for multiple `fx`/`fy` combinations (parametrized), identity preservation, and constant-image scaling
- **Rotate** — shape preservation at 0/90/180/270°, identity at 0°, and sentinel-pixel location verified via `np.unravel_index(argmax)` to handle interpolation rounding
- **Reflect** — pixel-exact X/Y/Both flip modes (parametrized), unknown type fallback to X, and shape preservation
- **Affine** — output shape, sentinel pixel translated by (dx=50, dy=100), and out-of-bounds shift cases

## Screenshots (if applicable)

N/A — backend only.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
