### PR TITLE
feat(filtering): add hough line detection operator #51

### DIFF
--- a/imagelab-backend/app/operators/filtering/hough_lines.py
+++ b/imagelab-backend/app/operators/filtering/hough_lines.py
@@ -1,0 +1,63 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+from app.utils.color import hex_to_bgr
+
+
+class HoughLines(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        rho = float(self.params.get("rho", 1.0))
+        theta_degrees = float(self.params.get("thetaDegrees", 1.0))
+        theta = float(np.deg2rad(theta_degrees))
+        threshold_val = int(self.params.get("threshold", 50))
+        min_line_length = int(self.params.get("minLineLength", 50))
+        max_line_gap = int(self.params.get("maxLineGap", 10))
+        color_hex = self.params.get("color", "#00FF00")
+        thickness = int(self.params.get("thickness", 2))
+
+        if rho <= 0:
+            raise ValueError(f"'rho' must be > 0, got {rho}")
+        if theta_degrees <= 0:
+            raise ValueError(f"'thetaDegrees' must be > 0, got {theta_degrees}")
+        if thickness < 1:
+            raise ValueError(f"'thickness' must be >= 1, got {thickness}")
+
+        bgr_color = hex_to_bgr(color_hex)
+
+        if len(image.shape) == 3:
+            if image.shape[2] == 4:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image
+
+        canny_low = float(self.params.get("cannyThreshold1", 50))
+        canny_high = float(self.params.get("cannyThreshold2", 150))
+        aperture = int(self.params.get("cannyApertureSize", 3))
+
+        edges = cv2.Canny(gray, canny_low, canny_high, apertureSize=aperture)
+
+        lines = cv2.HoughLinesP(
+            edges,
+            rho=rho,
+            theta=theta,
+            threshold=threshold_val,
+            minLineLength=min_line_length,
+            maxLineGap=max_line_gap,
+        )
+
+        if len(image.shape) == 2:
+            output_base = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+        elif image.shape[2] == 4:
+            output_base = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+        else:
+            output_base = image.copy()
+
+        if lines is not None:
+            for line in lines:
+                x1, y1, x2, y2 = line[0]
+                cv2.line(output_base, (x1, y1), (x2, y2), bgr_color, thickness)
+
+        return output_base

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -34,6 +34,7 @@ from app.operators.filtering.contour_detection import ContourDetection
 from app.operators.filtering.dilation import Dilation
 from app.operators.filtering.erosion import Erosion
 from app.operators.filtering.gabor_filter import GaborFilter
+from app.operators.filtering.hough_lines import HoughLines
 from app.operators.filtering.laplacian import Laplacian
 from app.operators.filtering.laplacian import Laplacian as FilteringLaplacian
 from app.operators.filtering.morphological import Morphological
@@ -111,6 +112,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "augmentation_sepiafilter": SepiaFilter,
     "filtering_gaborfilter": GaborFilter,
     "filtering_contourdetection": ContourDetection,
+    "filtering_houghlines": HoughLines,
     # Thresholding
     "thresholding_applythreshold": ApplyThreshold,
     "thresholding_adaptivethreshold": AdaptiveThreshold,

--- a/imagelab-backend/tests/operators/filtering/test_hough_lines.py
+++ b/imagelab-backend/tests/operators/filtering/test_hough_lines.py
@@ -1,0 +1,117 @@
+import numpy as np
+
+from app.operators.filtering.hough_lines import HoughLines
+
+
+def test_hough_lines_preserves_shape() -> None:
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    out = HoughLines({}).compute(img)
+    assert out.shape == img.shape
+    assert np.array_equal(out, img)
+
+
+def test_hough_lines_detects_and_draws() -> None:
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    for i in range(10, 90):
+        img[i, i] = [255, 255, 255]
+
+    out = HoughLines(
+        {
+            "rho": 1.0,
+            "thetaDegrees": 1.0,
+            "threshold": 10,
+            "minLineLength": 10,
+            "maxLineGap": 5,
+            "color": "#FF0000",
+            "thickness": 1,
+        }
+    ).compute(img)
+
+    assert out.shape == img.shape
+    has_red = np.any(np.all(out == [0, 0, 255], axis=-1))
+    assert has_red, "No red pixel found in drawn image"
+
+
+def test_hough_lines_converts_theta_degrees_to_radians(monkeypatch) -> None:
+    captured: dict[str, float | int] = {}
+
+    def fake_hough_lines_p(
+        edges: np.ndarray,
+        rho: float,
+        theta: float,
+        threshold: int,
+        minLineLength: float,
+        maxLineGap: float,
+    ) -> None:
+        captured["rho"] = rho
+        captured["theta"] = theta
+        captured["threshold"] = threshold
+        captured["minLineLength"] = minLineLength
+        captured["maxLineGap"] = maxLineGap
+        return None
+
+    monkeypatch.setattr("app.operators.filtering.hough_lines.cv2.HoughLinesP", fake_hough_lines_p)
+
+    image = np.zeros((20, 20, 3), dtype=np.uint8)
+    out = HoughLines(
+        {
+            "rho": 2.0,
+            "thetaDegrees": 90.0,
+            "threshold": 7,
+            "minLineLength": 8,
+            "maxLineGap": 9,
+        }
+    ).compute(image)
+
+    assert np.array_equal(out, image)
+    assert captured["rho"] == 2.0
+    assert np.isclose(captured["theta"], np.pi / 2)
+    assert captured["threshold"] == 7
+    assert captured["minLineLength"] == 8.0
+    assert captured["maxLineGap"] == 9.0
+
+
+def test_hough_lines_draws_on_original_image_not_edge_map(monkeypatch) -> None:
+    def fake_hough_lines_p(
+        edges: np.ndarray,
+        rho: float,
+        theta: float,
+        threshold: int,
+        minLineLength: float,
+        maxLineGap: float,
+    ) -> np.ndarray:
+        return np.array([[[2, 2, 8, 2]]], dtype=np.int32)
+
+    monkeypatch.setattr("app.operators.filtering.hough_lines.cv2.HoughLinesP", fake_hough_lines_p)
+
+    image = np.full((12, 12, 3), fill_value=(10, 20, 30), dtype=np.uint8)
+    out = HoughLines({"color": "#FF0000", "thickness": 1}).compute(image)
+
+    assert np.array_equal(out[10, 10], image[10, 10])
+    assert np.array_equal(out[2, 2], np.array([0, 0, 255], dtype=np.uint8))
+
+
+def test_hough_lines_grayscale_input_returns_bgr() -> None:
+    img = np.zeros((50, 50), dtype=np.uint8)
+    for i in range(10, 40):
+        img[i, 25] = 255
+
+    out = HoughLines({"threshold": 5, "minLineLength": 5, "color": "#00FF00"}).compute(img)
+
+    assert len(out.shape) == 3
+    assert out.shape == (50, 50, 3)
+    has_green = np.any(np.all(out == [0, 255, 0], axis=-1))
+    assert has_green, "Grayscale image didn't convert and draw green lines"
+
+
+def test_hough_lines_draws_on_bgra_input(monkeypatch) -> None:
+    def fake_hough_lines_p(edges, rho, theta, threshold, minLineLength, maxLineGap):
+        return np.array([[[1, 1, 9, 1]]], dtype=np.int32)
+
+    monkeypatch.setattr("app.operators.filtering.hough_lines.cv2.HoughLinesP", fake_hough_lines_p)
+
+    image = np.full((12, 12, 4), fill_value=(10, 20, 30, 255), dtype=np.uint8)
+    out = HoughLines({"color": "#FF0000", "thickness": 1}).compute(image)
+
+    assert out.shape[2] in (3, 4), "BGRA input must return a valid image"
+    assert out[1, 1, 2] == 255, "Expected red channel 255 at drawn line pixel"

--- a/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
@@ -189,4 +189,56 @@ export const filteringBlocks = [
     tooltip:
       "Detects edges in the image using the Canny algorithm. threshold1 and threshold2 are the lower and upper bounds for the hysteresis procedure. apertureSize is the Sobel kernel size.",
   },
+  {
+    type: "filtering_houghlines",
+    message0:
+      "Apply Hough Line Detection | rho %1 theta(deg) %2 | threshold %3 minLength %4 | maxGap %5 color %6 | thickness %7 | cannyLow %8 cannyHigh %9 | cannyAperture %10",
+    args0: [
+      { type: "field_number", name: "rho", value: 1.0, min: 0.1, max: 10 },
+      {
+        type: "field_number",
+        name: "thetaDegrees",
+        value: 1.0,
+        min: 0.1,
+        max: 180,
+      },
+      { type: "field_number", name: "threshold", value: 50, min: 1, max: 500 },
+      { type: "field_number", name: "minLineLength", value: 50, min: 1, max: 2000 },
+      { type: "field_number", name: "maxLineGap", value: 10, min: 0, max: 500 },
+      { type: "field_colour", name: "color", colour: "#00FF00" },
+      {
+        type: "field_number",
+        name: "thickness",
+        value: 2,
+        min: 1,
+        max: 50,
+      },
+      {
+        type: "field_number",
+        name: "cannyThreshold1",
+        value: 50,
+        min: 0,
+        max: 255,
+      },
+      {
+        type: "field_number",
+        name: "cannyThreshold2",
+        value: 150,
+        min: 0,
+        max: 255,
+      },
+      {
+        type: "field_number",
+        name: "cannyApertureSize",
+        value: 3,
+        min: 3,
+        max: 7,
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "filtering_style",
+    tooltip:
+      "Applies Probabilistic Hough Line Transform to detect straight line segments. Internally converts to grayscale and uses Canny Edge Detection as a pre-step. 'rho' and 'theta(deg)' set the coordinate resolution. 'threshold' is the minimum votes to be considered a line. 'minLength' filters short segments, and 'maxGap' connects broken lines.",
+  },
 ];


### PR DESCRIPTION
Adds the Hough Line Detection Operator (probabilistic) to extract and draw straight lines using Canny edge preprocessing, addressing #51.

Fixes #51

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

cd imagelab-backend
uv run pytest -v tests/operators/filtering/test_hough_lines.py

- [ ] Existing tests pass
- [x] New tests added
- [ ] Manual testing

Coverage highlights:
- Validated shape preservation (returns unchanged image if no lines detected)
- Validated correct line drawing onto the original image using specified hex color/thickness
- Tested grayscale -> BGR auto-conversion for color line drawing

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
