### PR TITLE
test: verify continue-on-error for fork PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+# Test: verify continue-on-error works for fork PRs
 name: Lint
 
 on:


### PR DESCRIPTION
## Summary
- Dummy PR to trigger the lint workflow and verify `continue-on-error: true` on `github-script` steps doesn't break normal (non-fork) PR behavior
- Comments should still be posted/deleted normally since the token has write access on same-repo PRs
- This PR should be closed after verification

## What to check
- [ ] `frontend-lint` job completes (comment steps run or skip as expected)
- [ ] `backend-lint` job completes (comment steps run or skip as expected)
- [ ] `rebase-check` job completes (comment steps run or skip as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)