### PR TITLE
feature: persist Blockly workspace in localStorage

### DIFF
--- a/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
+++ b/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
@@ -7,41 +7,21 @@ import { WorkspaceSearch } from "@blockly/plugin-workspace-search";
 import { usePipelineStore } from "../store/pipelineStore";
 import { imagelabTheme } from "../blocks/theme";
 import { SINGLETON_BLOCK_TYPES } from "../utils/blockLimits";
+import {
+  clearPersistedWorkspace,
+  loadPersistedWorkspaceState,
+  saveWorkspaceState,
+} from "./workspacePersistence";
 
-const STORAGE_KEY = "imagelab.pipeline.workspace.v1";
 const SAVE_DEBOUNCE_MS = 500;
-const STORAGE_TTL_MS = 3 * 60 * 60 * 1000;
+const MUTATING_EVENTS = new Set<string>([
+  Blockly.Events.BLOCK_CREATE,
+  Blockly.Events.BLOCK_DELETE,
+  Blockly.Events.BLOCK_CHANGE,
+  Blockly.Events.BLOCK_MOVE,
+]);
+
 type WorkspaceState = ReturnType<typeof Blockly.serialization.workspaces.save>;
-
-function loadPersistedWorkspaceState(): WorkspaceState | null {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return null;
-
-  try {
-    const payload = JSON.parse(raw) as {
-      expiresAt?: number;
-      data?: WorkspaceState;
-    };
-
-    if (!payload.expiresAt || Date.now() > payload.expiresAt || !payload.data) {
-      localStorage.removeItem(STORAGE_KEY);
-      return null;
-    }
-
-    return payload.data;
-  } catch {
-    localStorage.removeItem(STORAGE_KEY);
-    return null;
-  }
-}
-
-function saveWorkspaceState(state: WorkspaceState) {
-  const payload = {
-    expiresAt: Date.now() + STORAGE_TTL_MS,
-    data: state,
-  };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-}
 
 export function useBlocklyWorkspace() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -80,9 +60,15 @@ export function useBlocklyWorkspace() {
       },
     });
     // Load persisted workspace state if available and valid
-    const persistedState = loadPersistedWorkspaceState();
+    const persistedState = loadPersistedWorkspaceState<WorkspaceState>();
     if (persistedState) {
-      Blockly.serialization.workspaces.load(persistedState, ws);
+      try {
+        Blockly.serialization.workspaces.load(persistedState, ws);
+      } catch (err) {
+        console.warn("[ImageLab] Failed to restore workspace state; clearing persisted data.", err);
+        clearPersistedWorkspace();
+        // workspace is already blank — no further action needed
+      }
     }
 
     ws.addChangeListener((event: Blockly.Events.Abstract) => {
@@ -118,12 +104,7 @@ export function useBlocklyWorkspace() {
       }
 
       // Debounced save on any change that modifies the workspace (create, delete, change, move)
-      if (
-        event.type === Blockly.Events.BLOCK_CREATE ||
-        event.type === Blockly.Events.BLOCK_DELETE ||
-        event.type === Blockly.Events.BLOCK_CHANGE ||
-        event.type === Blockly.Events.BLOCK_MOVE
-      ) {
+      if (!event.isUiEvent && MUTATING_EVENTS.has(event.type)) {
         // Clear any existing save timeout to debounce rapid changes
         if (saveTimeoutRef.current !== null) {
           window.clearTimeout(saveTimeoutRef.current);
@@ -145,14 +126,19 @@ export function useBlocklyWorkspace() {
   useEffect(() => {
     initWorkspace();
     return () => {
-      //  Cleanup on unmount: dispose workspace and clear any pending save timeout
+      // Cleanup on unmount: dispose workspace and clear any pending save timeout
       if (saveTimeoutRef.current !== null) {
         window.clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+        // Flush the save synchronously so the last change is not lost
+        if (workspaceRef.current) {
+          const state = Blockly.serialization.workspaces.save(workspaceRef.current);
+          saveWorkspaceState(state);
+        }
       }
       if (workspaceRef.current) {
         workspaceRef.current.dispose();
         workspaceRef.current = null;
-        setWorkspace(null);
       }
     };
   }, [initWorkspace]);

--- a/imagelab-frontend/src/hooks/workspacePersistence.ts
+++ b/imagelab-frontend/src/hooks/workspacePersistence.ts
@@ -1,0 +1,60 @@
+export const WORKSPACE_STORAGE_KEY = "imagelab.pipeline.workspace.v1";
+export const WORKSPACE_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type PersistedPayload<T> = {
+  expiresAt?: number;
+  data?: T;
+};
+
+export function loadPersistedWorkspaceState<T>(
+  storage: Storage = localStorage,
+  key = WORKSPACE_STORAGE_KEY,
+): T | null {
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+
+  try {
+    const payload = JSON.parse(raw) as PersistedPayload<T>;
+    if (
+      typeof payload.expiresAt !== "number" ||
+      Date.now() > payload.expiresAt ||
+      !payload.data ||
+      typeof payload.data !== "object"
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return payload.data;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function saveWorkspaceState<T extends object>(
+  state: T,
+  storage: Storage = localStorage,
+  key = WORKSPACE_STORAGE_KEY,
+  ttlMs = WORKSPACE_STORAGE_TTL_MS,
+): boolean {
+  const payload = {
+    expiresAt: Date.now() + ttlMs,
+    data: state,
+  };
+
+  try {
+    storage.setItem(key, JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    // Quota exceeded or storage unavailable; persistence is best-effort.
+    console.warn("[ImageLab] Could not persist workspace state:", err);
+    return false;
+  }
+}
+
+export function clearPersistedWorkspace(
+  storage: Storage = localStorage,
+  key = WORKSPACE_STORAGE_KEY,
+): void {
+  storage.removeItem(key);
+}

--- a/imagelab-frontend/tests/hooks/workspacePersistence.test.ts
+++ b/imagelab-frontend/tests/hooks/workspacePersistence.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WORKSPACE_STORAGE_KEY,
+  clearPersistedWorkspace,
+  loadPersistedWorkspaceState,
+  saveWorkspaceState,
+} from "../../src/hooks/workspacePersistence";
+
+class LocalStorageMock implements Storage {
+  public readonly store = new Map<string, string>();
+  public throwOnSet = false;
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) {
+      const err = new Error("Quota exceeded");
+      err.name = "QuotaExceededError";
+      throw err;
+    }
+    this.store.set(key, value);
+  }
+}
+
+describe("loadPersistedWorkspaceState", () => {
+  let storage: LocalStorageMock;
+
+  beforeEach(() => {
+    storage = new LocalStorageMock();
+  });
+
+  it("returns null for expired entries and removes the key", () => {
+    storage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() - 1000,
+        data: { blocks: [] },
+      }),
+    );
+
+    const result = loadPersistedWorkspaceState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes the key for malformed JSON", () => {
+    storage.setItem(WORKSPACE_STORAGE_KEY, "{not-json");
+
+    const result = loadPersistedWorkspaceState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes the key for missing expiresAt", () => {
+    storage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        data: { blocks: [] },
+      }),
+    );
+
+    const result = loadPersistedWorkspaceState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes the key for missing data", () => {
+    storage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+
+    const result = loadPersistedWorkspaceState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns state when payload is valid and unexpired", () => {
+    const state = { blocks: [{ id: "a" }] };
+    storage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 60_000,
+        data: state,
+      }),
+    );
+
+    const result = loadPersistedWorkspaceState<typeof state>(storage);
+
+    expect(result).toEqual(state);
+  });
+});
+
+describe("saveWorkspaceState", () => {
+  let storage: LocalStorageMock;
+
+  beforeEach(() => {
+    storage = new LocalStorageMock();
+  });
+
+  it("writes payload with expiresAt in the future", () => {
+    const state = { blocks: [{ id: "node-1" }] };
+    const now = Date.now();
+    const ok = saveWorkspaceState(state, storage, WORKSPACE_STORAGE_KEY, 10_000);
+
+    expect(ok).toBe(true);
+    const raw = storage.getItem(WORKSPACE_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const payload = JSON.parse(raw!) as { expiresAt: number; data: typeof state };
+    expect(payload.data).toEqual(state);
+    expect(payload.expiresAt).toBeGreaterThanOrEqual(now + 10_000);
+  });
+
+  it("does not throw when localStorage throws QuotaExceededError", () => {
+    storage.throwOnSet = true;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => saveWorkspaceState({ blocks: [] }, storage)).not.toThrow();
+    expect(saveWorkspaceState({ blocks: [] }, storage)).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  it("round-trips saved payload through load", () => {
+    const state = { blocks: [{ id: "x" }, { id: "y" }] };
+    saveWorkspaceState(state, storage, WORKSPACE_STORAGE_KEY, 60_000);
+
+    const loaded = loadPersistedWorkspaceState<typeof state>(storage);
+
+    expect(loaded).toEqual(state);
+  });
+});
+
+describe("clearPersistedWorkspace", () => {
+  it("removes the persisted key", () => {
+    const storage = new LocalStorageMock();
+    storage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify({ expiresAt: Date.now() + 1, data: {} }));
+
+    clearPersistedWorkspace(storage);
+
+    expect(storage.getItem(WORKSPACE_STORAGE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds a minimal pipeline persistence layer in the frontend by serializing the Blockly workspace and storing it in browser localStorage.

Fixes #104 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
https://github.com/user-attachments/assets/92146e5b-453c-4ca0-b710-56aeb3bfa107

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally
