### PR TITLE
Frontend Unit Tests for Pipeline Extraction

### DIFF
--- a/imagelab-frontend/package-lock.json
+++ b/imagelab-frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -34,7 +35,8 @@
         "tailwindcss": "^4.2.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -336,6 +338,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@blockly/field-angle": {
@@ -1578,6 +1590,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.0.tgz",
@@ -1894,6 +1913,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2242,6 +2279,148 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2313,6 +2492,35 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2421,6 +2629,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2593,6 +2811,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2833,6 +3058,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2841,6 +3076,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3030,6 +3275,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3140,6 +3392,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3594,6 +3885,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3650,6 +3982,17 @@
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -3746,6 +4089,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3980,6 +4330,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3989,6 +4346,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4043,6 +4414,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4058,6 +4446,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -4289,6 +4687,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -4359,6 +4835,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/imagelab-frontend/package.json
+++ b/imagelab-frontend/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css}\"",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@blockly/field-angle": "^6.0.8",
@@ -29,6 +31,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
@@ -37,6 +40,7 @@
     "tailwindcss": "^4.2.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/imagelab-frontend/src/hooks/__tests__/blockly.mock.ts
+++ b/imagelab-frontend/src/hooks/__tests__/blockly.mock.ts
@@ -1,0 +1,113 @@
+/**
+ * Reusable Blockly mock factory functions.
+ *
+ * These helpers build minimal, realistic Blockly object shapes that satisfy
+ * the API surface used by `extractPipeline()` in `usePipeline.ts`. They are
+ * designed to be composable so future tests can reuse them without repetition.
+ *
+ * Blockly API surface exercised by extractPipeline():
+ *   workspace.getTopBlocks(ordered: boolean) → Block[]
+ *   block.type                            → string
+ *   block.inputList                       → Input[]
+ *   block.getNextBlock()                  → Block | null
+ *   input.fieldRow                        → Field[]
+ *   input.connection?.targetBlock()       → Block | null
+ *   input.type                            → number  (1 = VALUE input)
+ *   field.name                            → string
+ *   field.getValue()                      → string
+ */
+
+
+// ─── Field ────────────────────────────────────────────────────────────────────
+
+export interface MockField {
+  name: string;
+  getValue: () => string;
+}
+
+/**
+ * Create a mock Blockly Field.
+ *
+ * @param name  - The `field.name` identifier (empty string means "skip this field").
+ * @param value - The value returned by `field.getValue()`.
+ */
+export function makeField(name: string, value: string): MockField {
+  return { name, getValue: () => value };
+}
+
+// ─── Input ────────────────────────────────────────────────────────────────────
+
+export interface MockConnection {
+  targetBlock: () => MockBlock | null;
+}
+
+export interface MockInput {
+  fieldRow: MockField[];
+  connection: MockConnection | undefined;
+  type: number;
+}
+
+/**
+ * Create a mock Blockly Input.
+ *
+ * @param fields      - Array of fields on this input's fieldRow.
+ * @param targetBlock - Optional block connected to this input via a VALUE connection.
+ * @param inputType   - Blockly input type number. 1 = VALUE (default for connected blocks), 0 = STATEMENT.
+ */
+export function makeInput(
+  fields: MockField[],
+  targetBlock?: MockBlock | null,
+  inputType = 0,
+): MockInput {
+  return {
+    fieldRow: fields,
+    connection: targetBlock !== undefined
+      ? { targetBlock: () => targetBlock }
+      : undefined,
+    type: inputType,
+  };
+}
+
+// ─── Block ────────────────────────────────────────────────────────────────────
+
+export interface MockBlock {
+  type: string;
+  inputList: MockInput[];
+  getNextBlock: () => MockBlock | null;
+}
+
+/**
+ * Create a mock Blockly Block.
+ *
+ * @param type      - The block's type string (e.g. `"basic_readimage"`).
+ * @param inputs    - Array of inputs on `block.inputList`.
+ * @param nextBlock - The next block in the statement chain, or null.
+ */
+export function makeBlock(
+  type: string,
+  inputs: MockInput[] = [],
+  nextBlock: MockBlock | null = null,
+): MockBlock {
+  return {
+    type,
+    inputList: inputs,
+    getNextBlock: () => nextBlock,
+  };
+}
+
+// ─── Workspace ────────────────────────────────────────────────────────────────
+
+export interface MockWorkspace {
+  getTopBlocks: (ordered: boolean) => MockBlock[];
+}
+
+/**
+ * Create a mock Blockly WorkspaceSvg.
+ *
+ * @param topBlocks - The blocks returned by `workspace.getTopBlocks(true)`.
+ */
+export function makeWorkspace(topBlocks: MockBlock[]): MockWorkspace {
+  return {
+    getTopBlocks: () => topBlocks,
+  };
+}

--- a/imagelab-frontend/src/hooks/__tests__/usePipeline.test.ts
+++ b/imagelab-frontend/src/hooks/__tests__/usePipeline.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for extractPipeline() in usePipeline.ts
+ *
+ * Strategy: We mock Blockly's workspace / block / input / field objects using
+ * plain JavaScript objects that satisfy the exact properties accessed by
+ * extractPipeline(). No real Blockly DOM or registration is needed.
+ *
+ * The Blockly.WorkspaceSvg type is cast via `as unknown as Blockly.WorkspaceSvg`
+ * so TypeScript is happy while we avoid importing the full Blockly runtime.
+ */
+
+import { describe, it, expect } from "vitest";
+import type * as Blockly from "blockly";
+
+import { extractPipeline } from "../usePipeline";
+import {
+  makeField,
+  makeInput,
+  makeBlock,
+  makeWorkspace,
+  type MockWorkspace,
+} from "./blockly.mock";
+
+/** Cast our lightweight mock to the type extractPipeline() expects. */
+function asWorkspace(mock: MockWorkspace): Blockly.WorkspaceSvg {
+  return mock as unknown as Blockly.WorkspaceSvg;
+}
+
+// ─── Empty / missing readimage ────────────────────────────────────────────────
+
+describe("extractPipeline — empty / missing readimage", () => {
+  it("returns [] for an empty workspace", () => {
+    const workspace = makeWorkspace([]);
+    expect(extractPipeline(asWorkspace(workspace))).toEqual([]);
+  });
+
+  it("returns [] when no basic_readimage block exists", () => {
+    // Workspace has blocks, but none are the required entry-point type.
+    const unrelated = makeBlock("geometric_rotateimage", [
+      makeInput([makeField("angle", "90")]),
+    ]);
+    const workspace = makeWorkspace([unrelated]);
+    expect(extractPipeline(asWorkspace(workspace))).toEqual([]);
+  });
+});
+
+// ─── Single block ─────────────────────────────────────────────────────────────
+
+describe("extractPipeline — single block", () => {
+  it("returns a single step with empty params for a readimage block with no named fields", () => {
+    // basic_readimage has a field_label_serializable ("filename_label") but
+    // the label's name value could be empty; here we simulate no name fields.
+    const readBlock = makeBlock("basic_readimage", [makeInput([])]);
+    const workspace = makeWorkspace([readBlock]);
+    expect(extractPipeline(asWorkspace(workspace))).toEqual([
+      { type: "basic_readimage", params: {} },
+    ]);
+  });
+
+  it("extracts numeric field params correctly", () => {
+    // Mirrors geometric_rotateimage: field_angle + field_number
+    const readBlock = makeBlock("basic_readimage", [
+      makeInput([
+        makeField("angle", "45"),
+        makeField("scale", "1.5"),
+      ]),
+    ]);
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+    expect(result).toHaveLength(1);
+    expect(result[0].params).toEqual({ angle: "45", scale: "1.5" });
+  });
+
+  it("extracts dropdown field params correctly", () => {
+    // Mirrors geometric_reflectimage: field_dropdown named "type"
+    const readBlock = makeBlock("basic_readimage", [
+      makeInput([makeField("type", "X")]),
+    ]);
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+    expect(result[0].params).toEqual({ type: "X" });
+  });
+
+  it("extracts color field params correctly", () => {
+    // Mirrors drawingoperations_drawline: field_colour named "rgbcolors_input"
+    const readBlock = makeBlock("basic_readimage", [
+      makeInput([makeField("rgbcolors_input", "#2828cc")]),
+    ]);
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+    expect(result[0].params).toEqual({ rgbcolors_input: "#2828cc" });
+  });
+
+  it("skips fields whose name is an empty string", () => {
+    // Blockly labels / anonymous fields have name === "" and should be ignored.
+    const readBlock = makeBlock("basic_readimage", [
+      makeInput([
+        makeField("", "ignored"),      // unnamed — should be skipped
+        makeField("strength", "1.5"),  // named — should be captured
+      ]),
+    ]);
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+    expect(result[0].params).toEqual({ strength: "1.5" });
+    expect(Object.keys(result[0].params)).not.toContain("");
+  });
+});
+
+// ─── Block chain traversal ────────────────────────────────────────────────────
+
+describe("extractPipeline — block chain traversal", () => {
+  it("returns steps in chain order (readimage is first, writeimage is last)", () => {
+    const writeBlock = makeBlock("basic_writeimage", [], null);
+    const rotateBlock = makeBlock(
+      "geometric_rotateimage",
+      [makeInput([makeField("angle", "90"), makeField("scale", "1")])],
+      writeBlock,
+    );
+    const readBlock = makeBlock("basic_readimage", [], rotateBlock);
+
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+
+    expect(result).toHaveLength(3);
+    expect(result[0].type).toBe("basic_readimage");
+    expect(result[1].type).toBe("geometric_rotateimage");
+    expect(result[2].type).toBe("basic_writeimage");
+  });
+
+  it("extracts params for each block in the chain independently", () => {
+    const blurBlock = makeBlock("filtering_bilateral", [
+      makeInput([
+        makeField("filterSize", "5"),
+        makeField("sigmaColor", "75"),
+        makeField("sigmaSpace", "75"),
+      ]),
+    ]);
+    const rotateBlock = makeBlock(
+      "geometric_rotateimage",
+      [makeInput([makeField("angle", "45"), makeField("scale", "2")])],
+      blurBlock,
+    );
+    const readBlock = makeBlock("basic_readimage", [], rotateBlock);
+
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+
+    expect(result).toHaveLength(3);
+    expect(result[1].params).toEqual({ angle: "45", scale: "2" });
+    expect(result[2].params).toEqual({ filterSize: "5", sigmaColor: "75", sigmaSpace: "75" });
+  });
+
+  it("stops traversal at the end of the chain (null next block)", () => {
+    const readBlock = makeBlock("basic_readimage", [], null);
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ─── VALUE-type connected child block ─────────────────────────────────────────
+
+describe("extractPipeline — VALUE input child block merging", () => {
+  /**
+   * The INPUT_TYPE_VALUE constant inside usePipeline.ts is 1.
+   * When an input has type === 1 and a connected block, that child block's
+   * fields are merged into the parent step's params.
+   */
+  const INPUT_TYPE_VALUE = 1;
+  const INPUT_TYPE_STATEMENT = 0;
+
+  it("merges child block fields into parent step params for VALUE inputs", () => {
+    // Simulates a border-value block plugged into an applyborders block.
+    const childBlock = makeBlock("some_value_block", [
+      makeInput([makeField("borderType", "REFLECT")]),
+    ]);
+    const parentInput = makeInput(
+      [makeField("iterations", "3")],
+      childBlock,
+      INPUT_TYPE_VALUE,
+    );
+    const readBlock = makeBlock("basic_readimage", [parentInput]);
+
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+
+    // Child's field is merged into the parent step's params.
+    expect(result[0].params).toEqual({ iterations: "3", borderType: "REFLECT" });
+  });
+
+  it("does NOT merge child block fields for non-VALUE (statement) inputs", () => {
+    const childBlock = makeBlock("some_statement_block", [
+      makeInput([makeField("shouldNotAppear", "oops")]),
+    ]);
+    const parentInput = makeInput(
+      [makeField("myParam", "good")],
+      childBlock,
+      INPUT_TYPE_STATEMENT, // type = 0, not a VALUE input
+    );
+    const readBlock = makeBlock("basic_readimage", [parentInput]);
+
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+
+    expect(result[0].params).toEqual({ myParam: "good" });
+    expect(result[0].params).not.toHaveProperty("shouldNotAppear");
+  });
+
+  it("handles a VALUE input with no connected block gracefully", () => {
+    // connection exists but targetBlock() returns null
+    const parentInput = makeInput(
+      [makeField("param", "value")],
+      null,       // targetBlock() will return null
+      INPUT_TYPE_VALUE,
+    );
+    const readBlock = makeBlock("basic_readimage", [parentInput]);
+
+    const workspace = makeWorkspace([readBlock]);
+    const result = extractPipeline(asWorkspace(workspace));
+
+    expect(result[0].params).toEqual({ param: "value" });
+  });
+});

--- a/imagelab-frontend/vite.config.ts
+++ b/imagelab-frontend/vite.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+/// <reference types="vitest" />
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  server: { port: 3100 }
-})
+  server: { port: 3100 },
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
**# Frontend Unit Tests for Pipeline Extraction**

**## Summary**

Adds comprehensive Vitest test coverage for the `extractPipeline()` function in `imagelab-frontend/src/hooks/usePipeline.ts` — the critical bridge between the Blockly visual editor and the backend execution API.

Fix - #49 

**## Acceptance Criteria**

- [x] Tests exist for the pipeline extraction logic
- [x] Mock factory functions create realistic Blockly block and workspace objects
- [x] Tests cover: empty workspace, single block, chain of blocks, numeric fields, dropdown fields, color fields
- [x] Tests verify correct block traversal order (first block in chain is first step)
- [x] Tests verify parameter extraction accuracy
- [x] All tests pass with `npm test`
- [x] Mocks are structured to be reusable for future tests

**## Changes**

**### Test Infrastructure**

- **Installed `vitest` and `@vitest/coverage-v8`** as dev dependencies
- **Added `npm test` and `npm run test:coverage` scripts** to `package.json`
- **Configured Vitest** in `vite.config.ts` (`globals: true`, `environment: node`)

**### New Files**

| File                                      | Description                                                      |
| ----------------------------------------- | ---------------------------------------------------------------- |
| `src/hooks/__tests__/blockly.mock.ts`     | Reusable factory functions for mocking the Blockly workspace API |
| `src/hooks/__tests__/usePipeline.test.ts` | 13 tests covering all acceptance criteria                        |

**## Mock Factory Design**

`blockly.mock.ts` exports four composable helpers that build realistic Blockly object shapes without requiring a real Blockly runtime or DOM:

```ts
makeField(name, value)              // → Field with getName() / getValue()
makeInput(fields, targetBlock?, type?) // → Input with fieldRow + optional connection
makeBlock(type, inputs?, next?)     // → Block with inputList + getNextBlock()
makeWorkspace(topBlocks)            // → WorkspaceSvg with getTopBlocks()
```

These are designed to be reused by future tests that exercise other Blockly-dependent logic.

**## Test Coverage**

| Describe Block            | Tests                                                                                  |
| ------------------------- | -------------------------------------------------------------------------------------- |
| Empty / missing readimage | Empty workspace → `[]`; unrelated blocks only → `[]`                                   |
| Single block              | No fields, numeric fields, dropdown fields, color fields, unnamed fields skipped       |
| Chain traversal           | 3-block chain in correct order; per-block param isolation; stops cleanly at null       |
| VALUE input child merging | Child fields merged for `type === 1`; skipped for statement inputs; null child handled |

## Test Results

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  ~1.3s
```
<img width="1092" height="536" alt="Screenshot 2026-03-01 022319" src="https://github.com/user-attachments/assets/d04fad46-b915-418e-b0f6-dabf20da3621" />

**## How to Run**

```bash
cd imagelab-frontend
npm test               # run all tests
npm run test:coverage  # run with coverage report
```