### PR TITLE
Add Pipeline Execution Timing Display

### DIFF
--- a/imagelab-backend/app/models/pipeline.py
+++ b/imagelab-backend/app/models/pipeline.py
@@ -12,9 +12,21 @@ class PipelineRequest(BaseModel):
     pipeline: list[PipelineStep]
 
 
+class StepTiming(BaseModel):
+    step: int
+    type: str
+    duration_ms: float
+
+
+class PipelineTimings(BaseModel):
+    total_ms: float
+    steps: list[StepTiming]
+
+
 class PipelineResponse(BaseModel):
     success: bool
     image: str | None = None
     image_format: str | None = None
     error: str | None = None
     step: int | None = None
+    timings: PipelineTimings | None = None

--- a/imagelab-backend/app/services/pipeline_executor.py
+++ b/imagelab-backend/app/services/pipeline_executor.py
@@ -1,4 +1,6 @@
-from app.models.pipeline import PipelineRequest, PipelineResponse
+import time
+
+from app.models.pipeline import PipelineRequest, PipelineResponse, PipelineTimings, StepTiming
 from app.operators.registry import get_operator
 from app.utils.image import decode_base64_image, encode_image_base64
 
@@ -6,6 +8,9 @@ NOOP_TYPES = {"basic_readimage", "basic_writeimage", "border_for_all", "border_e
 
 
 def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
+    total_start = time.perf_counter()
+    step_timings: list[StepTiming] = []
+
     try:
         image = decode_base64_image(request.image)
     except Exception as e:
@@ -24,8 +29,13 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             )
 
         try:
+            t0 = time.perf_counter()
             operator = operator_cls(step.params)
             image = operator.compute(image)
+            t1 = time.perf_counter()
+            step_timings.append(
+                StepTiming(step=i, type=step.type, duration_ms=(t1 - t0) * 1000)
+            )
         except Exception as e:
             return PipelineResponse(
                 success=False,
@@ -39,8 +49,11 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
         error_msg = f"Failed to encode result: {type(e).__name__}: {e}"
         return PipelineResponse(success=False, error=error_msg, step=len(request.pipeline))
 
+    total_ms = (time.perf_counter() - total_start) * 1000
+
     return PipelineResponse(
         success=True,
         image=encoded,
         image_format=request.image_format,
+        timings=PipelineTimings(total_ms=total_ms, steps=step_timings),
     )

--- a/imagelab-frontend/src/components/Preview/PreviewPane.tsx
+++ b/imagelab-frontend/src/components/Preview/PreviewPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ZoomIn, ZoomOut, Image, ImageDown, Trash2 } from "lucide-react";
+import { ZoomIn, ZoomOut, Image, ImageDown, Trash2, Timer } from "lucide-react";
 import { usePipelineStore } from "../../store/pipelineStore";
 import ImageDisplay from "./ImageDisplay";
 
@@ -34,8 +34,13 @@ function ZoomControls({
   );
 }
 
+/** Strip common block prefixes (e.g. "geometric_rotateimage" → "rotateimage") */
+function formatStepType(type: string): string {
+  return type.replace(/^[a-z]+_/, "");
+}
+
 export default function PreviewPane() {
-  const { originalImage, imageFormat, processedImage, error, errorStep, clearImage } =
+  const { originalImage, imageFormat, processedImage, error, errorStep, timings, clearImage } =
     usePipelineStore();
   const [originalZoom, setOriginalZoom] = useState<number | null>(null);
   const [processedZoom, setProcessedZoom] = useState<number | null>(null);
@@ -44,6 +49,9 @@ export default function PreviewPane() {
     setter((prev) => Math.min((prev ?? 300) + 100, 2500));
   const zoomOut = (setter: React.Dispatch<React.SetStateAction<number | null>>) => () =>
     setter((prev) => Math.max((prev ?? 300) - 100, 100));
+
+  /** Width of the per-step duration bar relative to the slowest step */
+  const maxStepMs = timings ? Math.max(...timings.steps.map((s) => s.duration_ms), 1) : 1;
 
   return (
     <div className="w-80 h-full bg-white border-l border-gray-200 flex flex-col flex-shrink-0">
@@ -83,6 +91,12 @@ export default function PreviewPane() {
           <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
             Processed
           </h2>
+          {timings && (
+            <span className="ml-auto flex items-center gap-1 px-1.5 py-0.5 bg-emerald-50 text-emerald-700 rounded text-[10px] font-semibold">
+              <Timer size={10} />
+              {timings.total_ms.toFixed(1)} ms
+            </span>
+          )}
         </div>
         <div className="flex-1 flex items-center justify-center p-3 bg-gray-50 overflow-auto">
           {processedImage ? (
@@ -101,6 +115,43 @@ export default function PreviewPane() {
             <p className="text-xs text-red-600">{error}</p>
           </div>
         )}
+
+        {/* Per-step timing — collapsible */}
+        {timings && timings.steps.length > 0 && (
+          <details className="border-t border-gray-200">
+            <summary className="px-3 py-1.5 flex items-center gap-1.5 cursor-pointer select-none hover:bg-gray-50 transition-colors list-none">
+              <Timer size={12} className="text-gray-400" />
+              <span className="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">
+                Step Timings
+              </span>
+              <span className="ml-auto text-[10px] text-gray-400">
+                {timings.steps.length} step{timings.steps.length !== 1 ? "s" : ""}
+              </span>
+            </summary>
+            <div className="px-3 py-2 space-y-1.5 max-h-40 overflow-y-auto">
+              {timings.steps.map((s) => (
+                <div key={s.step} className="flex items-center gap-2">
+                  <span className="text-[10px] text-gray-400 w-4 text-right shrink-0">
+                    {s.step}
+                  </span>
+                  <span className="text-[10px] text-gray-600 truncate flex-1" title={s.type}>
+                    {formatStepType(s.type)}
+                  </span>
+                  <div className="w-12 h-1.5 bg-gray-100 rounded-full overflow-hidden shrink-0">
+                    <div
+                      className="h-full bg-emerald-400 rounded-full"
+                      style={{ width: `${(s.duration_ms / maxStepMs) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-[10px] text-gray-500 w-12 text-right shrink-0">
+                    {s.duration_ms.toFixed(1)} ms
+                  </span>
+                </div>
+              ))}
+            </div>
+          </details>
+        )}
+
         <ZoomControls
           disabled={!processedImage}
           onZoomIn={zoomIn(setProcessedZoom)}

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -23,6 +23,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     setProcessedImage,
     setExecuting,
     setError,
+    setTiming,
     reset,
     blockCount,
     uniqueBlockTypes,
@@ -60,6 +61,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
     setExecuting(true);
     setError(null);
+    setTiming(null);
 
     try {
       const response = await executePipeline({
@@ -70,6 +72,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
       if (response.success && response.image) {
         setProcessedImage(response.image);
+        setTiming(response.timings ?? null);
       } else {
         setError(response.error || "Pipeline execution failed", response.step);
       }

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import * as Blockly from "blockly";
 import { categories } from "../blocks/categories";
+import type { PipelineTimings } from "../types/pipeline";
 
 interface PipelineState {
   originalImage: string | null;
@@ -11,6 +12,7 @@ interface PipelineState {
   errorStep: number | null;
   selectedBlockType: string | null;
   selectedBlockTooltip: string | null;
+  timings: PipelineTimings | null;
 
   // Statistics
   blockCount: number;
@@ -22,6 +24,7 @@ interface PipelineState {
   setExecuting: (executing: boolean) => void;
   setError: (error: string | null, step?: number | null) => void;
   setSelectedBlock: (type: string | null, tooltip: string | null) => void;
+  setTiming: (timings: PipelineTimings | null) => void;
   updateBlockStats: (workspace: Blockly.WorkspaceSvg) => void;
   reset: () => void;
   clearImage: () => void;
@@ -45,6 +48,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   errorStep: null,
   selectedBlockType: null,
   selectedBlockTooltip: null,
+  timings: null,
   blockCount: 0,
   uniqueBlockTypes: 0,
   categoryCounts: {},
@@ -53,15 +57,16 @@ export const usePipelineStore = create<PipelineState>((set) => ({
     set({ originalImage: image, imageFormat: format, processedImage: null, error: null }),
   setProcessedImage: (image) => set({ processedImage: image, error: null, errorStep: null }),
   setExecuting: (executing) => set({ isExecuting: executing }),
-  setError: (error, step = null) => set({ error, errorStep: step }),
+  setError: (error, step = null) => set({ error, errorStep: step, timings: null }),
   setSelectedBlock: (type, tooltip) =>
     set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
+  setTiming: (timings) => set({ timings }),
   _imageResetFn: null as (() => void) | null,
   registerImageReset: (fn) => set({ _imageResetFn: fn }),
   clearImage: () => {
     const state = usePipelineStore.getState();
     if (state._imageResetFn) state._imageResetFn();
-    set({ originalImage: null, processedImage: null, error: null, errorStep: null });
+    set({ originalImage: null, processedImage: null, error: null, errorStep: null, timings: null });
   },
   updateBlockStats: (workspace) => {
     const blocks = workspace.getAllBlocks(false);
@@ -99,6 +104,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       errorStep: null,
       selectedBlockType: null,
       selectedBlockTooltip: null,
+      timings: null,
       blockCount: 0,
       uniqueBlockTypes: 0,
       categoryCounts: {},

--- a/imagelab-frontend/src/types/pipeline.ts
+++ b/imagelab-frontend/src/types/pipeline.ts
@@ -9,10 +9,22 @@ export interface PipelineRequest {
   pipeline: PipelineStep[];
 }
 
+export interface StepTiming {
+  step: number;
+  type: string;
+  duration_ms: number;
+}
+
+export interface PipelineTimings {
+  total_ms: number;
+  steps: StepTiming[];
+}
+
 export interface PipelineResponse {
   success: boolean;
   image?: string;
   image_format?: string;
   error?: string;
   step?: number;
+  timings?: PipelineTimings;
 }


### PR DESCRIPTION
**# Add Pipeline Execution Timing Display**

**## Summary**

Adds per-step and total execution timing to the ImageLab pipeline. Timing is measured on the backend using `time.perf_counter`, returned in the API response, and displayed in the Preview panel with a total-time badge and a collapsible per-step breakdown.

Fix - #65 

**## Acceptance Criteria**

- [x] The pipeline API response includes total duration and per-step timing data
- [x] Per-step timing includes the step index, operator type, and duration in milliseconds
- [x] Each pipeline step is individually timed using a high-resolution timer (`time.perf_counter`)
- [x] Total pipeline duration is measured (including image decode/encode)
- [x] Timing data is returned in the API response alongside the processed image
- [x] The frontend data model is updated to handle timing fields from the API
- [x] Total execution time is displayed in the UI after pipeline execution
- [x] Per-step timing is available in a collapsible detail view
- [x] Timing is cleared when a new pipeline execution starts
- [x] Timing display does not appear when no pipeline has been executed
- [x] Existing API consumers are not broken (timing fields are optional/nullable)

**## Changes**

**### Backend**

#### `imagelab-backend/app/models/pipeline.py`

- Added `StepTiming` model — `step`, `type`, `duration_ms`
- Added `PipelineTimings` model — `total_ms`, `steps: list[StepTiming]`
- Extended `PipelineResponse` with optional `timings: PipelineTimings | None = None`

#### `imagelab-backend/app/services/pipeline_executor.py`

- Imported `time` for `time.perf_counter()`
- Wraps total execution (decode + all steps + encode) with a wall-clock timer
- Each non-NOOP operator call is individually timed and collected as `StepTiming`
- `timings` is returned on success; error responses are unchanged

**### Frontend**

#### `imagelab-frontend/src/types/pipeline.ts`

- Added `StepTiming` and `PipelineTimings` TypeScript interfaces
- Added optional `timings?: PipelineTimings` to `PipelineResponse`

#### `imagelab-frontend/src/store/pipelineStore.ts`

- Added `timings: PipelineTimings | null` state field
- Added `setTiming(timings)` action
- `setError`, `clearImage`, and `reset` all clear `timings` to null

#### `imagelab-frontend/src/components/Toolbar.tsx`

- Clears timing (`setTiming(null)`) at the start of each run
- Stores timing from the response (`setTiming(response.timings ?? null)`) on success

#### `imagelab-frontend/src/components/Preview/PreviewPane.tsx`

- Displays a green `⏱ 52.2 ms` badge next to the "Processed" header after a run
- Adds a collapsible "Step Timings" section with per-step rows showing:
  - Step index, operator name (prefix stripped), mini duration bar, and ms value
- Badge and breakdown are hidden when no pipeline has run

**## API Response Example**

```json
{
  "success": true,
  "image": "...",
  "timings": {
    "total_ms": 52.22,
    "steps": [
      { "step": 1, "type": "geometric_rotateimage", "duration_ms": 7.21 }
    ]
  }
}
```

**## Backward Compatibility**

`timings` is `| None = None` on the backend (Pydantic) and `timings?` (optional) on the frontend — all existing API consumers remain unaffected.

**## How to Test**

1. Load an image using the **Read Image** block
2. Connect one or more processing blocks (e.g. Rotate, Blur)
3. Click **Run**
4. The **Processed** header shows a green timing badge (e.g. `⏱ 48.3 ms`)
5. Click **Step Timings** to expand the per-step breakdown
6. Click **Run** again — timing clears immediately, then updates with fresh values
7. Trigger a pipeline error — confirm no timing badge appears

**## Result**
<img width="1918" height="944" alt="Screenshot 2026-03-01 025013" src="https://github.com/user-attachments/assets/481f892e-cc29-4dc5-98c8-2f702950cfdf" />
