### PR TITLE
fix(conversions): handle grayscale input safely in GrayImage

### DIFF
--- a/imagelab-backend/app/operators/conversions/gray_image.py
+++ b/imagelab-backend/app/operators/conversions/gray_image.py
@@ -6,4 +6,16 @@ from app.operators.base import BaseOperator
 
 class GrayImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        if image.ndim == 2:
+            return image
+
+        if image.ndim == 3:
+            channels = image.shape[2]
+            if channels == 1:
+                return image[:, :, 0]
+            if channels == 3:
+                return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            if channels == 4:
+                return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+
+        raise ValueError("GrayImage expects a 2D grayscale image or a 3D image with 1, 3, or 4 channels")

--- a/imagelab-backend/app/operators/conversions/gray_image.py
+++ b/imagelab-backend/app/operators/conversions/gray_image.py
@@ -6,16 +6,32 @@ from app.operators.base import BaseOperator
 
 class GrayImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        if image.ndim == 2:
-            return image
+        """
+        Convert *image* to a 2-D (H × W) grayscale array.
 
-        if image.ndim == 3:
+        Supported input formats
+        -----------------------
+        * 2-D ``(H, W)``         — already grayscale; returned as a copy.
+        * 3-D ``(H, W, 1)``      — single-channel packed; channel axis is squeezed, returned as a copy.
+        * 3-D ``(H, W, 3)``      — **BGR** (OpenCV convention) → grayscale.
+        * 3-D ``(H, W, 4)``      — **BGRA** (OpenCV convention) → grayscale; alpha ignored.
+
+        Raises
+        ------
+        ValueError
+            For any other dimensionality or channel count.
+        """
+        if image.ndim == 2:
+            return image.copy()
+        elif image.ndim == 3:
             channels = image.shape[2]
             if channels == 1:
-                return image[:, :, 0]
-            if channels == 3:
+                return image[:, :, 0].copy()
+            elif channels == 3:
                 return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-            if channels == 4:
+            elif channels == 4:
                 return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
 
-        raise ValueError("GrayImage expects a 2D grayscale image or a 3D image with 1, 3, or 4 channels")
+        raise ValueError(
+            f"GrayImage expects a 2D or 3D image with 1/3/4 channels, got ndim={image.ndim}, shape={image.shape}"
+        )

--- a/imagelab-backend/tests/operators/conversions/test_gray_image.py
+++ b/imagelab-backend/tests/operators/conversions/test_gray_image.py
@@ -12,6 +12,10 @@ def test_gray_image_returns_2d_grayscale_input_unchanged() -> None:
 
     assert out.shape == image.shape
     assert np.array_equal(out, image)
+    assert out is not image, "compute() must return a copy, not the original array"
+    # Verify no aliasing:
+    out[0, 0] = 255
+    assert image[0, 0] != 255, "Mutating output must not affect input"
 
 
 def test_gray_image_converts_bgr_to_grayscale() -> None:
@@ -25,6 +29,9 @@ def test_gray_image_converts_bgr_to_grayscale() -> None:
 
     assert out.shape == (6, 6)
     assert np.array_equal(out, expected)
+    # B=10, G=20, R=30: Y ≈ 22 (OpenCV integer approximation)
+    assert int(out[0, 0]) == int(expected[0, 0])
+    assert int(out[0, 0]) == 22
 
 
 def test_gray_image_converts_bgra_to_grayscale() -> None:
@@ -39,6 +46,9 @@ def test_gray_image_converts_bgra_to_grayscale() -> None:
 
     assert out.shape == (6, 6)
     assert np.array_equal(out, expected)
+    # B=10, G=20, R=30: Y ≈ 22 (OpenCV integer approximation)
+    assert int(out[0, 0]) == int(expected[0, 0])
+    assert int(out[0, 0]) == 22
 
 
 def test_gray_image_handles_single_channel_3d_input() -> None:
@@ -48,13 +58,23 @@ def test_gray_image_handles_single_channel_3d_input() -> None:
 
     assert out.shape == (8, 8)
     assert np.array_equal(out, image[:, :, 0])
+    assert out is not image[:, :, 0], "compute() must return a copy"
+    # Verify no aliasing:
+    out[0, 0] = 255
+    assert image[0, 0, 0] != 255, "Mutating output must not affect input"
 
 
-def test_gray_image_rejects_unsupported_channel_count() -> None:
-    image = np.zeros((4, 4, 2), dtype=np.uint8)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (10,),  # 1-D flat array
+        (4, 4, 2),  # 3-D, 2-channel
+        (4, 4, 5),  # 3-D, 5-channel
+        (2, 4, 4, 3),  # 4-D batch
+    ],
+)
+def test_gray_image_rejects_unsupported_shapes(shape: tuple) -> None:
+    image = np.zeros(shape, dtype=np.uint8)
 
-    with pytest.raises(
-        ValueError,
-        match="GrayImage expects a 2D grayscale image or a 3D image with 1, 3, or 4 channels",
-    ):
+    with pytest.raises(ValueError, match=r"GrayImage expects"):
         GrayImage({}).compute(image)

--- a/imagelab-backend/tests/operators/conversions/test_gray_image.py
+++ b/imagelab-backend/tests/operators/conversions/test_gray_image.py
@@ -1,0 +1,60 @@
+import cv2
+import numpy as np
+import pytest
+
+from app.operators.conversions.gray_image import GrayImage
+
+
+def test_gray_image_returns_2d_grayscale_input_unchanged() -> None:
+    image = np.arange(100, dtype=np.uint8).reshape(10, 10)
+
+    out = GrayImage({}).compute(image)
+
+    assert out.shape == image.shape
+    assert np.array_equal(out, image)
+
+
+def test_gray_image_converts_bgr_to_grayscale() -> None:
+    image = np.zeros((6, 6, 3), dtype=np.uint8)
+    image[:, :, 0] = 10
+    image[:, :, 1] = 20
+    image[:, :, 2] = 30
+
+    out = GrayImage({}).compute(image)
+    expected = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+    assert out.shape == (6, 6)
+    assert np.array_equal(out, expected)
+
+
+def test_gray_image_converts_bgra_to_grayscale() -> None:
+    image = np.zeros((6, 6, 4), dtype=np.uint8)
+    image[:, :, 0] = 10
+    image[:, :, 1] = 20
+    image[:, :, 2] = 30
+    image[:, :, 3] = 255
+
+    out = GrayImage({}).compute(image)
+    expected = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+
+    assert out.shape == (6, 6)
+    assert np.array_equal(out, expected)
+
+
+def test_gray_image_handles_single_channel_3d_input() -> None:
+    image = np.arange(64, dtype=np.uint8).reshape(8, 8, 1)
+
+    out = GrayImage({}).compute(image)
+
+    assert out.shape == (8, 8)
+    assert np.array_equal(out, image[:, :, 0])
+
+
+def test_gray_image_rejects_unsupported_channel_count() -> None:
+    image = np.zeros((4, 4, 2), dtype=np.uint8)
+
+    with pytest.raises(
+        ValueError,
+        match="GrayImage expects a 2D grayscale image or a 3D image with 1, 3, or 4 channels",
+    ):
+        GrayImage({}).compute(image)


### PR DESCRIPTION
## Description

Fixes the `GrayImage` conversion crash when input is already grayscale (single-channel). The operator now handles 1/3/4-channel inputs safely and raises a clear error for unsupported channel layouts. Added regression tests for grayscale, BGR, BGRA, and invalid 2-channel input.

Fixes #118

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added operator-level regression tests:
- `test_gray_image_returns_2d_grayscale_input_unchanged`
- `test_gray_image_converts_bgr_to_grayscale`
- `test_gray_image_converts_bgra_to_grayscale`
- `test_gray_image_handles_single_channel_3d_input`
- `test_gray_image_rejects_unsupported_channel_count`

Manual runtime validation done in backend venv with OpenCV installed:
- Grayscale input no longer crashes and remains unchanged
- BGR/BGRA paths match OpenCV expected output
- Unsupported channel count raises `ValueError`

- [ ] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally