### PR TITLE
fix(geometric): prevent ScaleImage crash when fx/fy are zero or negative

### DIFF
--- a/imagelab-backend/app/operators/geometric/scale_image.py
+++ b/imagelab-backend/app/operators/geometric/scale_image.py
@@ -24,4 +24,7 @@ class ScaleImage(BaseOperator):
             )
         interpolation_flag = _INTERPOLATION_MAP[interpolation_str]
 
+        if fx <= 0 or fy <= 0:
+            raise ValueError("fx and fy must be greater than 0")
+
         return cv2.resize(image, dsize=(0, 0), fx=fx, fy=fy, interpolation=interpolation_flag)

--- a/imagelab-backend/app/operators/geometric/scale_image.py
+++ b/imagelab-backend/app/operators/geometric/scale_image.py
@@ -1,3 +1,5 @@
+import math
+
 import cv2
 import numpy as np
 
@@ -14,8 +16,19 @@ _INTERPOLATION_MAP: dict[str, int] = {
 
 class ScaleImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        fx = float(self.params.get("fx", 1))
-        fy = float(self.params.get("fy", 1))
+        try:
+            fx = float(self.params.get("fx", 1))
+            fy = float(self.params.get("fy", 1))
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"fx and fy must be numeric values: {e}") from e
+
+        if not math.isfinite(fx) or not math.isfinite(fy):
+            raise ValueError(f"fx and fy must be finite numeric values, got fx={fx}, fy={fy}")
+
+        if fx <= 0:
+            raise ValueError(f"fx must be greater than 0, got {fx}")
+        if fy <= 0:
+            raise ValueError(f"fy must be greater than 0, got {fy}")
 
         interpolation_str = str(self.params.get("interpolation", "LINEAR")).upper()
         if interpolation_str not in _INTERPOLATION_MAP:
@@ -24,7 +37,6 @@ class ScaleImage(BaseOperator):
             )
         interpolation_flag = _INTERPOLATION_MAP[interpolation_str]
 
-        if fx <= 0 or fy <= 0:
-            raise ValueError("fx and fy must be greater than 0")
-
-        return cv2.resize(image, dsize=(0, 0), fx=fx, fy=fy, interpolation=interpolation_flag)
+        rows, cols = image.shape[:2]
+        new_size = (max(1, int(cols * fx)), max(1, int(rows * fy)))
+        return cv2.resize(image, new_size, interpolation=interpolation_flag)

--- a/imagelab-backend/tests/operators/geometric/test_scale_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_scale_image.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.scale_image import ScaleImage
+
+
+def test_scale_image_resizes_with_positive_factors() -> None:
+    image = np.zeros((10, 20, 3), dtype=np.uint8)
+
+    out = ScaleImage({"fx": 1.5, "fy": 0.5}).compute(image)
+
+    assert out.shape == (5, 30, 3)
+
+
+@pytest.mark.parametrize(
+    ("fx", "fy"),
+    [
+        (0, 1),
+        (1, 0),
+        (-1, 1),
+        (1, -1),
+    ],
+)
+def test_scale_image_rejects_non_positive_scale_factors(fx: float, fy: float) -> None:
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="fx and fy must be greater than 0"):
+        ScaleImage({"fx": fx, "fy": fy}).compute(image)

--- a/imagelab-backend/tests/operators/geometric/test_scale_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_scale_image.py
@@ -4,6 +4,13 @@ import pytest
 from app.operators.geometric.scale_image import ScaleImage
 
 
+def test_scale_image_uses_default_factors_of_one() -> None:
+    """ScaleImage({}) with no params defaults fx=1, fy=1 — output shape equals input."""
+    image = np.zeros((10, 20, 3), dtype=np.uint8)
+    out = ScaleImage({}).compute(image)
+    assert out.shape == image.shape
+
+
 def test_scale_image_resizes_with_positive_factors() -> None:
     image = np.zeros((10, 20, 3), dtype=np.uint8)
 
@@ -19,10 +26,16 @@ def test_scale_image_resizes_with_positive_factors() -> None:
         (1, 0),
         (-1, 1),
         (1, -1),
+        (0, 0),
+        (-1, -1),
+        (float("nan"), 1),
+        (1, float("nan")),
+        (float("inf"), 1),
+        (1, float("inf")),
     ],
 )
-def test_scale_image_rejects_non_positive_scale_factors(fx: float, fy: float) -> None:
+def test_scale_image_rejects_invalid_scale_factors(fx: float, fy: float) -> None:
     image = np.zeros((10, 10, 3), dtype=np.uint8)
 
-    with pytest.raises(ValueError, match="fx and fy must be greater than 0"):
+    with pytest.raises(ValueError):
         ScaleImage({"fx": fx, "fy": fy}).compute(image)

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -104,4 +104,3 @@ export const geometricBlocks = [
       "Applies a fixed affine transformation (translate by 50, 100) - Transforms the image using a predefined affine transformation that translates the image by 50 pixels in the X direction and 100 pixels in the Y direction. This block is useful for demonstrating basic affine transformations, which can include translation, rotation, scaling, and shearing.",
   },
 ];
-

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -36,8 +36,8 @@ export const geometricBlocks = [
     type: "geometric_scaleimage",
     message0: "Scale Image by %1 in X axis and by %2 in Y axis | Interpolation %3",
     args0: [
-      { type: "field_number", name: "fx", value: 1, min: 0 },
-      { type: "field_number", name: "fy", value: 1, min: 0 },
+      { type: "field_number", name: "fx", value: 1, min: 0.01, precision: 0.01 },
+      { type: "field_number", name: "fy", value: 1, min: 0.01, precision: 0.01 },
       {
         type: "field_dropdown",
         name: "interpolation",
@@ -104,3 +104,4 @@ export const geometricBlocks = [
       "Applies a fixed affine transformation (translate by 50, 100) - Transforms the image using a predefined affine transformation that translates the image by 50 pixels in the X direction and 100 pixels in the Y direction. This block is useful for demonstrating basic affine transformations, which can include translation, rotation, scaling, and shearing.",
   },
 ];
+


### PR DESCRIPTION
## Description

Fixes a runtime crash in `ScaleImage` when `fx` or `fy` are `0` (or negative). Added backend validation with a clear error message and tightened frontend block constraints to disallow invalid values from the UI.

Fixes #120

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- Added regression tests for `ScaleImage`:
  - valid positive scale factors resize correctly
  - non-positive factors (`0`, negative) raise `ValueError`
- Manual backend validation in venv (`SCALEIMAGE_FIX_VALIDATED`)
- Frontend lint check (`npm run -s lint`)

- [ ] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally