### PR TITLE
fix(filtering): correct BoxFilter width/height kernel order

### DIFF
--- a/imagelab-backend/app/operators/filtering/box_filter.py
+++ b/imagelab-backend/app/operators/filtering/box_filter.py
@@ -14,6 +14,7 @@ class BoxFilter(BaseOperator):
         return cv2.boxFilter(
             image,
             depth,
+<<<<<<< HEAD
             (width, height),  # OpenCV ksize convention: (width, height)
             anchor=(point_x, point_y),
             normalize=True,

--- a/imagelab-backend/app/operators/filtering/box_filter.py
+++ b/imagelab-backend/app/operators/filtering/box_filter.py
@@ -14,7 +14,6 @@ class BoxFilter(BaseOperator):
         return cv2.boxFilter(
             image,
             depth,
-<<<<<<< HEAD
             (width, height),  # OpenCV ksize convention: (width, height)
             anchor=(point_x, point_y),
             normalize=True,

--- a/imagelab-backend/tests/operators/filtering/test_box_filter.py
+++ b/imagelab-backend/tests/operators/filtering/test_box_filter.py
@@ -1,20 +1,48 @@
 import cv2
 import numpy as np
+import pytest
 
 from app.operators.filtering.box_filter import BoxFilter
 
 
 def test_box_filter_uses_width_height_kernel_order() -> None:
+    """Regression test for #125: kernel was applied as (height, width) instead of (width, height).
+    An asymmetric kernel (width=3, height=5) is used so the two orderings produce different output,
+    making the test sensitive to the exact bug it guards against.
+    """
     image = np.arange(8 * 9, dtype=np.uint8).reshape(8, 9)
 
-    out = BoxFilter({"width": 3, "height": 5, "depth": -1, "point_x": -1, "point_y": -1}).compute(image)
+    box_filter = BoxFilter({"width": 3, "height": 5, "depth": -1, "point_x": -1, "point_y": -1})
+    out = box_filter.compute(image)
+
+    correct_expected = cv2.boxFilter(image, -1, (3, 5), anchor=(-1, -1), normalize=True, borderType=cv2.BORDER_DEFAULT)
+    swapped_expected = cv2.boxFilter(image, -1, (5, 3), anchor=(-1, -1), normalize=True, borderType=cv2.BORDER_DEFAULT)
+
+    # Sanity check: the two orderings must differ so this test is meaningful
+    assert not np.array_equal(correct_expected, swapped_expected)
+    assert np.array_equal(out, correct_expected)
+
+
+def test_box_filter_uniform_image_is_unchanged() -> None:
+    """Box filter on a uniform image should return the same pixel values."""
+    image = np.full((10, 10), 128, dtype=np.uint8)
+    box_filter = BoxFilter({"width": 3, "height": 3, "depth": -1, "point_x": -1, "point_y": -1})
+    out = box_filter.compute(image)
+    assert np.all(out == 128)
+
+
+@pytest.mark.parametrize("width,height", [(3, 3), (3, 5), (5, 3), (1, 7)])
+def test_box_filter_kernel_shapes(width: int, height: int) -> None:
+    """BoxFilter output matches cv2.boxFilter for various kernel dimensions."""
+    image = np.random.randint(0, 256, (20, 20), dtype=np.uint8)
+    box_filter = BoxFilter({"width": width, "height": height, "depth": -1, "point_x": -1, "point_y": -1})
+    out = box_filter.compute(image)
     expected = cv2.boxFilter(
         image,
         -1,
-        (3, 5),
+        (width, height),
         anchor=(-1, -1),
         normalize=True,
         borderType=cv2.BORDER_DEFAULT,
     )
-
     assert np.array_equal(out, expected)

--- a/imagelab-backend/tests/operators/filtering/test_box_filter.py
+++ b/imagelab-backend/tests/operators/filtering/test_box_filter.py
@@ -1,0 +1,20 @@
+import cv2
+import numpy as np
+
+from app.operators.filtering.box_filter import BoxFilter
+
+
+def test_box_filter_uses_width_height_kernel_order() -> None:
+    image = np.arange(8 * 9, dtype=np.uint8).reshape(8, 9)
+
+    out = BoxFilter({"width": 3, "height": 5, "depth": -1, "point_x": -1, "point_y": -1}).compute(image)
+    expected = cv2.boxFilter(
+        image,
+        -1,
+        (3, 5),
+        anchor=(-1, -1),
+        normalize=True,
+        borderType=cv2.BORDER_DEFAULT,
+    )
+
+    assert np.array_equal(out, expected)


### PR DESCRIPTION
## Description

Fixes `BoxFilter` kernel argument ordering so `width` maps to kernel width and `height` maps to kernel height, matching block labels and expected OpenCV behavior. Added a regression test to lock this behavior.

Fixes #125

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- Added regression test: `imagelab-backend/tests/operators/filtering/test_box_filter.py`
- Manual backend validation in venv with OpenCV (`BOXFILTER_KERNEL_ORDER_FIX_VALIDATED`)

- [ ] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally