### PR TITLE
test: add unit tests for thresholding operators

### DIFF
--- a/imagelab-backend/tests/conftest.py
+++ b/imagelab-backend/tests/conftest.py
@@ -49,18 +49,6 @@ def png_b64() -> str:
     return base64.b64encode(buf.tobytes()).decode()
 
 
-@pytest.fixture
-def color_image():
-    rng = np.random.default_rng(42)
-    return rng.integers(0, 256, (100, 100, 3), dtype=np.uint8)
-
-
-@pytest.fixture
-def grayscale_image():
-    rng = np.random.default_rng(42)
-    return rng.integers(0, 256, (100, 100), dtype=np.uint8)
-
-
 @pytest.fixture(scope="session")
 def sample_image_b64() -> str:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)

--- a/imagelab-backend/tests/test_thresholding_operators.py
+++ b/imagelab-backend/tests/test_thresholding_operators.py
@@ -1,10 +1,9 @@
 import numpy as np
+import pytest
 
 from app.operators.thresholding.adaptive_threshold import AdaptiveThreshold
 from app.operators.thresholding.apply_threshold import ApplyThreshold
 from app.operators.thresholding.otsu_threshold import OtsuThreshold
-
-# ApplyThreshold
 
 
 class TestApplyThreshold:
@@ -16,25 +15,36 @@ class TestApplyThreshold:
         result = ApplyThreshold({}).compute(color_image)
         assert result.dtype == np.uint8
 
-    def test_default_max_value_produces_black_output(self, color_image):
+    @pytest.mark.xfail(
+        strict=True, reason="maxValue defaults to 0 — known bug, fix in fix/apply-threshold-default-max-value"
+    )
+    def test_default_params_produces_non_empty_output(self, color_image):
         result = ApplyThreshold({}).compute(color_image)
-        assert result.max() == 0
+        assert result.max() > 0
 
     def test_max_value_255_produces_binary_output(self, grayscale_image):
         result = ApplyThreshold({"maxValue": 255, "thresholdValue": 127}).compute(grayscale_image)
         unique = np.unique(result)
         assert set(unique).issubset({0, 255})
 
-    def test_threshold_value_0_with_max_255_sets_all_pixels(self, grayscale_image):
+    def test_threshold_value_0_pixels_above_zero_become_max(self, grayscale_image):
         result = ApplyThreshold({"maxValue": 255, "thresholdValue": 0}).compute(grayscale_image)
-        assert result.max() == 255
+        assert np.all(result[grayscale_image > 0] == 255)
+        assert np.all(result[grayscale_image == 0] == 0)
 
     def test_grayscale_input(self, grayscale_image):
         result = ApplyThreshold({"maxValue": 255, "thresholdValue": 127}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
 
+    def test_color_input_output_channels(self, color_image):
+        result = ApplyThreshold({"maxValue": 255, "thresholdValue": 127}).compute(color_image)
+        assert result.shape == color_image.shape
 
-# AdaptiveThreshold
+    def test_threshold_at_boundary(self):
+        img = np.array([[0, 127, 128, 255]], dtype=np.uint8)
+        result = ApplyThreshold({"maxValue": 255, "thresholdValue": 127}).compute(img)
+        expected = np.array([[0, 0, 255, 255]], dtype=np.uint8)
+        np.testing.assert_array_equal(result, expected)
 
 
 class TestAdaptiveThreshold:
@@ -77,8 +87,10 @@ class TestAdaptiveThreshold:
         result = AdaptiveThreshold({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
 
-
-# OtsuThreshold
+    def test_invalid_adaptive_method_falls_back_to_gaussian(self, color_image):
+        result_invalid = AdaptiveThreshold({"adaptiveMethod": "INVALID"}).compute(color_image)
+        result_gaussian = AdaptiveThreshold({"adaptiveMethod": "GAUSSIAN"}).compute(color_image)
+        np.testing.assert_array_equal(result_invalid, result_gaussian)
 
 
 class TestOtsuThreshold:
@@ -99,6 +111,12 @@ class TestOtsuThreshold:
         result = OtsuThreshold({}).compute(color_image)
         assert len(result.shape) == 2
 
+    def test_rgba_input(self, color_image):
+        rgba = np.dstack([color_image, np.full(color_image.shape[:2], 255, dtype=np.uint8)])
+        result = OtsuThreshold({}).compute(rgba)
+        assert len(result.shape) == 2
+        assert set(np.unique(result)).issubset({0, 255})
+
     def test_grayscale_input(self, grayscale_image):
         result = OtsuThreshold({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
@@ -107,3 +125,14 @@ class TestOtsuThreshold:
         result = OtsuThreshold({"maxValue": 128}).compute(grayscale_image)
         unique = np.unique(result)
         assert set(unique).issubset({0, 128})
+
+    def test_otsu_threshold_adapts_to_image_content(self):
+        dark_img = np.zeros((100, 100), dtype=np.uint8)
+        dark_img[:80, :] = 20
+        dark_img[80:, :] = 230
+        bright_img = np.zeros((100, 100), dtype=np.uint8)
+        bright_img[:20, :] = 20
+        bright_img[20:, :] = 230
+        result_dark = OtsuThreshold({"maxValue": 255}).compute(dark_img)
+        result_bright = OtsuThreshold({"maxValue": 255}).compute(bright_img)
+        assert result_dark.mean() != result_bright.mean()


### PR DESCRIPTION
## Description
Adds unit tests for the three thresholding operators: ApplyThreshold, AdaptiveThreshold, and OtsuThreshold. Tests cover output shape, dtype, binary output correctness, colour and RGBA input auto-conversion, even block size correction in AdaptiveThreshold, and a confirming test for the default maxValue=0 bug in ApplyThreshold which produces an all-black output.

To run the tests:
```
cd imagelab-backend
uv sync --extra dev
uv run pytest tests/test_thresholding_operators.py -v
```

Fixes #141 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

All 21 tests pass locally via `uv run pytest tests/test_thresholding_operators.py -v`.

## Screenshots (if applicable)


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally