### PR TITLE
fix: enable real-time snap and ghost for sidebar blocks

### DIFF
--- a/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
+++ b/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
@@ -14,6 +14,14 @@ import {
 } from "./workspacePersistence";
 
 const SAVE_DEBOUNCE_MS = 500;
+
+const SNAP_RADIUS = 48;
+const CONNECTING_SNAP_RADIUS = 68;
+
+// Apply global Blockly configuration once at module load
+Blockly.config.snapRadius = SNAP_RADIUS;
+Blockly.config.connectingSnapRadius = CONNECTING_SNAP_RADIUS;
+
 const MUTATING_EVENTS = new Set<string>([
   Blockly.Events.BLOCK_CREATE,
   Blockly.Events.BLOCK_DELETE,
@@ -33,6 +41,9 @@ export function useBlocklyWorkspace() {
 
   const initWorkspace = useCallback(() => {
     if (!containerRef.current || workspaceRef.current) return;
+
+    Blockly.config.snapRadius = 48;
+    Blockly.config.connectingSnapRadius = 68;
 
     const ws = Blockly.inject(containerRef.current, {
       readOnly: false,

--- a/imagelab-frontend/src/hooks/useSidebarDrag.ts
+++ b/imagelab-frontend/src/hooks/useSidebarDrag.ts
@@ -4,11 +4,30 @@ import { SINGLETON_BLOCK_TYPES, isSingletonBlockPresent } from "../utils/blockLi
 
 const DRAG_THRESHOLD = 5;
 
+function createSyntheticPointerEvent(e: MouseEvent): PointerEvent {
+  return new PointerEvent("pointermove", {
+    clientX: e.clientX,
+    clientY: e.clientY,
+    bubbles: true,
+    pointerId: 1,
+  });
+}
+
 interface UseSidebarDragOptions {
   type: string;
   label: string;
   workspace: Blockly.WorkspaceSvg | null;
   previewDataUrl?: string;
+}
+
+export function isOverWorkspace(
+  rect: DOMRect,
+  clientX: number,
+  clientY: number,
+): boolean {
+  return (
+    clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+  );
 }
 
 export function useSidebarDrag({ type, label, workspace, previewDataUrl }: UseSidebarDragOptions) {
@@ -17,10 +36,57 @@ export function useSidebarDrag({ type, label, workspace, previewDataUrl }: UseSi
   const ghostRef = useRef<HTMLDivElement | null>(null);
   const isDragging = useRef(false);
 
+  const blocklyBlockRef = useRef<Blockly.BlockSvg | null>(null);
+  const blocklyDragActive = useRef(false);
+  const eventGroupRef = useRef<string | null>(null);
+  const wsBoundsRef = useRef<DOMRect | null>(null);
+
   const removeGhost = useCallback(() => {
     if (ghostRef.current) {
       ghostRef.current.remove();
       ghostRef.current = null;
+    }
+  }, []);
+
+  const createAndPlaceBlock = useCallback(
+    (ws: Blockly.WorkspaceSvg, wsCoords: Blockly.utils.Coordinate) => {
+      if (SINGLETON_BLOCK_TYPES.has(type) && isSingletonBlockPresent(ws, type)) return null;
+      const block = ws.newBlock(type);
+      block.initSvg();
+      block.render();
+      block.moveTo(wsCoords);
+      return block;
+    },
+    [type]
+  );
+
+  const abortBlocklyDrag = useCallback((isSuccess = false) => {
+    if (blocklyBlockRef.current) {
+      if (!isSuccess) {
+        if (blocklyDragActive.current) {
+          try {
+            blocklyBlockRef.current.revertDrag();
+          } catch (err) {
+            if (import.meta.env.DEV) {
+              console.warn("[useSidebarDrag] revertDrag failed:", err);
+            }
+          }
+        }
+        try {
+          blocklyBlockRef.current.dispose(false);
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn("[useSidebarDrag] dispose failed:", err);
+          }
+        }
+      }
+      blocklyBlockRef.current = null;
+      blocklyDragActive.current = false;
+    }
+
+    if (eventGroupRef.current) {
+      Blockly.Events.setGroup(false);
+      eventGroupRef.current = null;
     }
   }, []);
 
@@ -32,78 +98,151 @@ export function useSidebarDrag({ type, label, workspace, previewDataUrl }: UseSi
   }, []);
 
   useEffect(() => {
+    let rafId: number | null = null;
+
     const onMouseMove = (e: MouseEvent) => {
-      if (!startPos.current) return;
+      if (rafId !== null) cancelAnimationFrame(rafId);
 
-      const dx = e.clientX - startPos.current.x;
-      const dy = e.clientY - startPos.current.y;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        if (!startPos.current) return;
 
-      if (!isDragging.current && Math.sqrt(dx * dx + dy * dy) > DRAG_THRESHOLD) {
-        isDragging.current = true;
-        wasDragged.current = true;
+        const dx = e.clientX - startPos.current.x;
+        const dy = e.clientY - startPos.current.y;
 
-        const ghost = document.createElement("div");
-        ghost.className = "sidebar-drag-ghost";
-        if (previewDataUrl) {
-          const img = document.createElement("img");
-          img.src = previewDataUrl;
-          img.style.maxWidth = "200px";
-          img.style.height = "auto";
-          img.style.display = "block";
-          ghost.appendChild(img);
-        } else {
-          ghost.classList.add("sidebar-drag-ghost--text");
-          ghost.textContent = label;
+        if (!isDragging.current && Math.sqrt(dx * dx + dy * dy) > DRAG_THRESHOLD) {
+          isDragging.current = true;
+          wasDragged.current = true;
+
+          const ghost = document.createElement("div");
+          ghost.className = "sidebar-drag-ghost";
+          ghost.style.pointerEvents = "none";
+          if (previewDataUrl) {
+            const img = document.createElement("img");
+            img.src = previewDataUrl;
+            img.style.maxWidth = "200px";
+            img.style.height = "auto";
+            img.style.display = "block";
+            ghost.appendChild(img);
+          } else {
+            ghost.classList.add("sidebar-drag-ghost--text");
+            ghost.textContent = label;
+          }
+          document.body.appendChild(ghost);
+          ghostRef.current = ghost;
         }
-        document.body.appendChild(ghost);
-        ghostRef.current = ghost;
-      }
 
-      if (isDragging.current && ghostRef.current) {
-        ghostRef.current.style.left = `${e.clientX + 10}px`;
-        ghostRef.current.style.top = `${e.clientY - 14}px`;
-      }
-    };
+        if (isDragging.current && ghostRef.current) {
+          ghostRef.current.style.left = `${e.clientX + 10}px`;
+          ghostRef.current.style.top = `${e.clientY - 14}px`;
+        }
+        if (!isDragging.current || !workspace) return;
 
-    const onMouseUp = (e: MouseEvent) => {
-      if (isDragging.current && workspace) {
-        removeGhost();
+        if (!wsBoundsRef.current) {
+          wsBoundsRef.current = workspace.getParentSvg().getBoundingClientRect();
+        }
 
-        const svgElement = workspace.getParentSvg();
-        const rect = svgElement.getBoundingClientRect();
+        const overWs = isOverWorkspace(wsBoundsRef.current, e.clientX, e.clientY);
 
-        if (
-          e.clientX >= rect.left &&
-          e.clientX <= rect.right &&
-          e.clientY >= rect.top &&
-          e.clientY <= rect.bottom
-        ) {
+        if (overWs && !blocklyBlockRef.current) {
           const wsCoords = Blockly.utils.svgMath.screenToWsCoordinates(
             workspace,
             new Blockly.utils.Coordinate(e.clientX, e.clientY),
           );
-          if (SINGLETON_BLOCK_TYPES.has(type) && isSingletonBlockPresent(workspace, type)) return;
-          const block = workspace.newBlock(type);
-          block.initSvg();
-          block.render();
-          block.moveTo(wsCoords);
+
+          try {
+            Blockly.Events.setGroup(true);
+            eventGroupRef.current = Blockly.Events.getGroup();
+
+            const block = createAndPlaceBlock(workspace, wsCoords);
+            if (!block) {
+              abortBlocklyDrag();
+              return;
+            }
+
+            blocklyBlockRef.current = block;
+            // Start drag first to register drag origin correctly, then hide ghost
+            block.startDrag(createSyntheticPointerEvent(e));
+            blocklyDragActive.current = true;
+            if (ghostRef.current) ghostRef.current.style.visibility = "hidden";
+          } catch (err) {
+            console.error("[useSidebarDrag] Failed to create drag block:", err);
+            abortBlocklyDrag();
+          }
+        } else if (overWs && blocklyBlockRef.current && blocklyDragActive.current) {
+          const wsCoords = Blockly.utils.svgMath.screenToWsCoordinates(
+            workspace,
+            new Blockly.utils.Coordinate(e.clientX, e.clientY),
+          );
+          blocklyBlockRef.current.drag(wsCoords, createSyntheticPointerEvent(e));
+        } else if (!overWs && blocklyBlockRef.current) {
+          abortBlocklyDrag(false);
+          if (ghostRef.current) ghostRef.current.style.visibility = "visible";
+        }
+      });
+    };
+
+    const onMouseUp = (e: MouseEvent) => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+
+      if (isDragging.current && workspace) {
+        removeGhost();
+
+        if (blocklyBlockRef.current && blocklyDragActive.current) {
+          try {
+            const pointerEvent = createSyntheticPointerEvent(e);
+            blocklyBlockRef.current.endDrag(pointerEvent);
+          } catch (err) {
+            console.error("[useSidebarDrag] endDrag failure:", err);
+            // Fallback: if endDrag fails, ensure block is cleaned if not committed
+            if (blocklyBlockRef.current) {
+              try { blocklyBlockRef.current.dispose(false); } catch { /* ignore */ }
+            }
+          } finally {
+            // Success flag for abortBlocklyDrag to clear remaining refs
+            abortBlocklyDrag(true);
+          }
+        } else if (!blocklyBlockRef.current) {
+          // Re-check bounds on mouseup in case mousemove didn't fire inside
+          const currentBounds = workspace.getParentSvg().getBoundingClientRect();
+          if (isOverWorkspace(currentBounds, e.clientX, e.clientY)) {
+            const wsCoords = Blockly.utils.svgMath.screenToWsCoordinates(
+              workspace,
+              new Blockly.utils.Coordinate(e.clientX, e.clientY),
+            );
+            createAndPlaceBlock(workspace, wsCoords);
+          }
         }
       }
+
+      const isSuccess = !!(blocklyBlockRef.current && blocklyDragActive.current);
+      abortBlocklyDrag(isSuccess);
 
       startPos.current = null;
       isDragging.current = false;
       removeGhost();
     };
 
+    const handleResize = () => {
+      wsBoundsRef.current = null;
+    };
+
     document.addEventListener("mousemove", onMouseMove);
     document.addEventListener("mouseup", onMouseUp);
+    window.addEventListener("resize", handleResize);
 
     return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
+      window.removeEventListener("resize", handleResize);
+      abortBlocklyDrag();
       removeGhost();
     };
-  }, [type, label, workspace, previewDataUrl, removeGhost]);
+  }, [type, label, workspace, previewDataUrl, removeGhost, abortBlocklyDrag, createAndPlaceBlock]);
 
   return { onMouseDown, wasDragged };
 }

--- a/imagelab-frontend/tests/hooks/useSidebarDrag.test.ts
+++ b/imagelab-frontend/tests/hooks/useSidebarDrag.test.ts
@@ -1,0 +1,304 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import * as Blockly from "blockly";
+import { useSidebarDrag } from "../../src/hooks/useSidebarDrag";
+import { isSingletonBlockPresent } from "../../src/utils/blockLimits";
+
+if (typeof PointerEvent === "undefined") {
+  (global as any).PointerEvent = class PointerEvent extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+    constructor(type: string, params: any = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId || 0;
+      this.pointerType = params.pointerType || "mouse";
+    }
+  };
+}
+
+vi.mock("blockly", () => {
+  return {
+    utils: {
+      Coordinate: function (this: any, x: number, y: number) {
+        this.x = x;
+        this.y = y;
+      },
+      svgMath: {
+        screenToWsCoordinates: vi.fn(() => ({ x: 0, y: 0 })),
+      },
+    },
+    Events: {
+      setGroup: vi.fn(),
+      getGroup: vi.fn(() => "mock-group"),
+    },
+  };
+});
+
+vi.mock("../../src/utils/blockLimits", () => ({
+  SINGLETON_BLOCK_TYPES: new Set(["singleton_type"]),
+  isSingletonBlockPresent: vi.fn(() => false),
+}));
+
+describe("useSidebarDrag", () => {
+  let mockBlock: any;
+  let mockWorkspace: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    
+    // Mock requestAnimationFrame
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+
+    mockBlock = {
+      initSvg: vi.fn(),
+      render: vi.fn(),
+      moveTo: vi.fn(),
+      startDrag: vi.fn(),
+      drag: vi.fn(),
+      endDrag: vi.fn(),
+      revertDrag: vi.fn(),
+      dispose: vi.fn(),
+    };
+
+    mockWorkspace = {
+      getParentSvg: vi.fn(() => ({
+        getBoundingClientRect: vi.fn(() => ({
+          left: 0,
+          top: 0,
+          right: 1000,
+          bottom: 1000,
+        })),
+      })),
+      newBlock: vi.fn(() => mockBlock),
+      getBlocksByType: vi.fn(() => []),
+    };
+
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  const triggerMouseDown = (onMouseDown: any, clientX = 10, clientY = 10) => {
+    act(() => {
+      onMouseDown({
+        button: 0,
+        clientX,
+        clientY,
+      } as any);
+    });
+  };
+
+  const triggerMouseMove = (clientX: number, clientY: number) => {
+    act(() => {
+      const event = new MouseEvent("mousemove", { clientX, clientY });
+      document.dispatchEvent(event);
+      vi.runAllTimers();
+    });
+  };
+
+  const triggerMouseUp = (clientX: number, clientY: number) => {
+    act(() => {
+      const event = new MouseEvent("mouseup", { clientX, clientY });
+      document.dispatchEvent(event);
+    });
+  };
+
+  it("should initialize a drag and create a ghost element after threshold", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+
+    const ghost = document.querySelector(".sidebar-drag-ghost");
+    expect(ghost).not.toBeNull();
+    expect(ghost?.textContent).toBe("Test Label");
+  });
+
+  it("should create a Blockly block when mouse enters workspace", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+
+    expect(mockWorkspace.newBlock).toHaveBeenCalledWith("test_block");
+    expect(mockBlock.initSvg).toHaveBeenCalled();
+    expect(mockBlock.render).toHaveBeenCalled();
+    expect(mockBlock.startDrag).toHaveBeenCalled();
+    expect(Blockly.Events.setGroup).toHaveBeenCalled();
+  });
+
+  it("should call drag on the block while moving over workspace", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+    triggerMouseMove(150, 150);
+
+    expect(mockBlock.drag).toHaveBeenCalled();
+  });
+
+  it("should abort drag and dispose block when mouse leaves workspace", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+    
+    mockWorkspace.getParentSvg.mockReturnValue({
+      getBoundingClientRect: () => ({ left: 200, top: 200, right: 300, bottom: 300 }),
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    
+    triggerMouseMove(50, 50);
+
+    expect(mockBlock.revertDrag).toHaveBeenCalled();
+    expect(mockBlock.dispose).toHaveBeenCalled();
+  });
+
+  it("should finalize block and close event group on mouseup inside workspace", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+    
+    triggerMouseUp(150, 150);
+
+    expect(mockBlock.endDrag).toHaveBeenCalled();
+    expect(mockBlock.dispose).not.toHaveBeenCalled();
+    expect(Blockly.Events.setGroup).toHaveBeenCalledWith(false);
+    expect(document.querySelector(".sidebar-drag-ghost")).toBeNull();
+  });
+
+  it("should not allow creating a block of singleton type if already present", () => {
+    vi.mocked(isSingletonBlockPresent).mockReturnValue(true);
+
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "singleton_type",
+        label: "Singleton",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+
+    expect(mockWorkspace.newBlock).not.toHaveBeenCalled();
+    expect(document.querySelector(".sidebar-drag-ghost")).not.toBeNull();
+  });
+
+  it("should handle startDrag failure and abort cleanly", () => {
+    mockBlock.startDrag.mockImplementation(() => {
+      throw new Error("startDrag failed");
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to create drag block"),
+      expect.any(Error)
+    );
+    expect(mockBlock.dispose).toHaveBeenCalled();
+    
+    consoleSpy.mockRestore();
+  });
+
+  it("should not create a block on mouseup outside workspace", () => {
+    const { result } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    mockWorkspace.getParentSvg.mockReturnValue({
+      getBoundingClientRect: () => ({ left: 500, top: 500, right: 1000, bottom: 1000 }),
+    });
+
+    triggerMouseDown(result.current.onMouseDown, 10, 10);
+    triggerMouseMove(50, 50); 
+    triggerMouseUp(60, 60); 
+
+    expect(mockWorkspace.newBlock).not.toHaveBeenCalled();
+    expect(document.querySelector(".sidebar-drag-ghost")).toBeNull();
+  });
+
+  it("should clean up Blockly block on unmount", () => {
+    const { result, unmount } = renderHook(() =>
+      useSidebarDrag({
+        type: "test_block",
+        label: "Test Label",
+        workspace: mockWorkspace,
+      })
+    );
+
+    triggerMouseDown(result.current.onMouseDown);
+    triggerMouseMove(50, 50);
+    triggerMouseMove(100, 100); 
+
+    unmount();
+
+    expect(mockBlock.revertDrag).toHaveBeenCalled();
+    expect(mockBlock.dispose).toHaveBeenCalled();
+    expect(document.querySelector(".sidebar-drag-ghost")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

Implemented real-time block snapping and ghost preview for blocks dragged from the sidebar. Now blocks snap immediately when dropped, and all dragged blocks show consistent visual feedback similar to existing workspace blocks.

Fixes #139 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

https://github.com/user-attachments/assets/e0a28965-74e5-4667-852f-a083c02f4ca5


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
