### PR TITLE
test: add unit tests for drawing operators

### DIFF
--- a/imagelab-backend/tests/conftest.py
+++ b/imagelab-backend/tests/conftest.py
@@ -49,18 +49,6 @@ def png_b64() -> str:
     return base64.b64encode(buf.tobytes()).decode()
 
 
-@pytest.fixture
-def color_image():
-    rng = np.random.default_rng(42)
-    return rng.integers(0, 256, (100, 100, 3), dtype=np.uint8)
-
-
-@pytest.fixture
-def grayscale_image():
-    rng = np.random.default_rng(42)
-    return rng.integers(0, 256, (100, 100), dtype=np.uint8)
-
-
 @pytest.fixture(scope="session")
 def sample_image_b64() -> str:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)

--- a/imagelab-backend/tests/test_drawing_operators.py
+++ b/imagelab-backend/tests/test_drawing_operators.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from app.operators.drawing.draw_arrow_line import DrawArrowLine
 from app.operators.drawing.draw_circle import DrawCircle
@@ -6,8 +7,6 @@ from app.operators.drawing.draw_ellipse import DrawEllipse
 from app.operators.drawing.draw_line import DrawLine
 from app.operators.drawing.draw_rectangle import DrawRectangle
 from app.operators.drawing.draw_text import DrawText
-
-# DrawLine
 
 
 class TestDrawLine:
@@ -26,7 +25,8 @@ class TestDrawLine:
         )
         np.testing.assert_array_equal(color_image, original)
 
-    def test_line_is_drawn(self, color_image):
+    def test_line_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawLine(
             {
                 "starting_point_x1": 0,
@@ -36,10 +36,10 @@ class TestDrawLine:
                 "rgbcolors_input": "#ff0000",
                 "thickness": 1,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[50, :, :].max() > 0
 
-    def test_custom_color_applied(self, color_image):
+    def test_custom_color_applied(self):
         blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawLine(
             {
@@ -56,9 +56,7 @@ class TestDrawLine:
     def test_grayscale_input(self, grayscale_image):
         result = DrawLine({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
-
-
-# DrawCircle
+        assert result.dtype == np.uint8
 
 
 class TestDrawCircle:
@@ -75,7 +73,8 @@ class TestDrawCircle:
         DrawCircle({"center_point_x": 50, "center_point_y": 50, "radius": 20}).compute(color_image)
         np.testing.assert_array_equal(color_image, original)
 
-    def test_circle_is_drawn(self, color_image):
+    def test_circle_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawCircle(
             {
                 "center_point_x": 50,
@@ -84,8 +83,8 @@ class TestDrawCircle:
                 "rgbcolors_input": "#ff0000",
                 "thickness": 2,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
 
     def test_custom_color_applied(self):
         blank = np.zeros((100, 100, 3), dtype=np.uint8)
@@ -103,9 +102,7 @@ class TestDrawCircle:
     def test_grayscale_input(self, grayscale_image):
         result = DrawCircle({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
-
-
-# DrawEllipse
+        assert result.dtype == np.uint8
 
 
 class TestDrawEllipse:
@@ -122,7 +119,8 @@ class TestDrawEllipse:
         DrawEllipse({"center_point_x": 50, "center_point_y": 50, "width": 30, "height": 20}).compute(color_image)
         np.testing.assert_array_equal(color_image, original)
 
-    def test_ellipse_is_drawn(self, color_image):
+    def test_ellipse_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawEllipse(
             {
                 "center_point_x": 50,
@@ -132,40 +130,45 @@ class TestDrawEllipse:
                 "rgbcolors_input": "#ff0000",
                 "thickness": 2,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
 
-    def test_axes_swap_bug(self):
+    def test_custom_color_applied(self):
         blank = np.zeros((100, 100, 3), dtype=np.uint8)
-        result_hw = DrawEllipse(
+        result = DrawEllipse(
             {
                 "center_point_x": 50,
                 "center_point_y": 50,
-                "height": 30,
+                "width": 30,
+                "height": 20,
+                "rgbcolors_input": "#ff0000",
+                "thickness": 2,
+            }
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
+
+    @pytest.mark.xfail(strict=True, reason="Known height/width axes swap bug in DrawEllipse")
+    def test_axes_swap_bug(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
+        result = DrawEllipse(
+            {
+                "center_point_x": 50,
+                "center_point_y": 50,
+                "height": 40,
                 "width": 10,
                 "rgbcolors_input": "#ffffff",
                 "thickness": 1,
             }
-        ).compute(blank.copy())
-        result_wh = DrawEllipse(
-            {
-                "center_point_x": 50,
-                "center_point_y": 50,
-                "height": 10,
-                "width": 30,
-                "rgbcolors_input": "#ffffff",
-                "thickness": 1,
-            }
-        ).compute(blank.copy())
-        # With correct axes order these should differ — currently they may not due to the swap bug
-        assert not np.array_equal(result_hw, result_wh)
+        ).compute(blank)
+        lit = np.argwhere(result[:, :, 0] > 0)
+        row_span = lit[:, 0].max() - lit[:, 0].min()
+        col_span = lit[:, 1].max() - lit[:, 1].min()
+        assert row_span > col_span
 
     def test_grayscale_input(self, grayscale_image):
         result = DrawEllipse({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
-
-
-# DrawRectangle
+        assert result.dtype == np.uint8
 
 
 class TestDrawRectangle:
@@ -184,7 +187,8 @@ class TestDrawRectangle:
         ).compute(color_image)
         np.testing.assert_array_equal(color_image, original)
 
-    def test_rectangle_is_drawn(self, color_image):
+    def test_rectangle_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawRectangle(
             {
                 "starting_point_x": 10,
@@ -194,8 +198,8 @@ class TestDrawRectangle:
                 "rgbcolors_input": "#ff0000",
                 "thickness": 2,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
 
     def test_custom_color_applied(self):
         blank = np.zeros((100, 100, 3), dtype=np.uint8)
@@ -214,9 +218,7 @@ class TestDrawRectangle:
     def test_grayscale_input(self, grayscale_image):
         result = DrawRectangle({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
-
-
-# DrawArrowLine
+        assert result.dtype == np.uint8
 
 
 class TestDrawArrowLine:
@@ -235,7 +237,8 @@ class TestDrawArrowLine:
         ).compute(color_image)
         np.testing.assert_array_equal(color_image, original)
 
-    def test_arrow_is_drawn(self, color_image):
+    def test_arrow_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawArrowLine(
             {
                 "starting_point_x": 10,
@@ -245,15 +248,27 @@ class TestDrawArrowLine:
                 "rgbcolors_input": "#ff0000",
                 "thickness": 2,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
+
+    def test_custom_color_applied(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
+        result = DrawArrowLine(
+            {
+                "starting_point_x": 10,
+                "starting_point_y": 50,
+                "ending_point_x": 90,
+                "ending_point_y": 50,
+                "rgbcolors_input": "#ff0000",
+                "thickness": 2,
+            }
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
 
     def test_grayscale_input(self, grayscale_image):
         result = DrawArrowLine({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
-
-
-# DrawText
+        assert result.dtype == np.uint8
 
 
 class TestDrawText:
@@ -270,7 +285,8 @@ class TestDrawText:
         DrawText({"draw_text": "Test", "starting_point_x": 10, "starting_point_y": 50}).compute(color_image)
         np.testing.assert_array_equal(color_image, original)
 
-    def test_text_is_drawn(self, color_image):
+    def test_text_is_drawn(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
         result = DrawText(
             {
                 "draw_text": "Test",
@@ -280,8 +296,22 @@ class TestDrawText:
                 "scale": 1,
                 "thickness": 2,
             }
-        ).compute(color_image)
-        assert not np.array_equal(result, color_image)
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
+
+    def test_custom_color_applied(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
+        result = DrawText(
+            {
+                "draw_text": "Test",
+                "starting_point_x": 10,
+                "starting_point_y": 50,
+                "rgbcolors_input": "#ff0000",
+                "scale": 1,
+                "thickness": 2,
+            }
+        ).compute(blank)
+        assert result[:, :, 2].max() > 0
 
     def test_empty_string_does_not_crash(self, color_image):
         result = DrawText({"draw_text": ""}).compute(color_image)
@@ -299,3 +329,4 @@ class TestDrawText:
     def test_grayscale_input(self, grayscale_image):
         result = DrawText({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
+        assert result.dtype == np.uint8


### PR DESCRIPTION
## Description
Adds unit tests for all six drawing operators: DrawLine, DrawCircle, DrawEllipse, DrawRectangle, DrawArrowLine, and DrawText. Tests cover output shape, dtype, original image immutability, draw verification, custom color correctness, grayscale input handling, and a confirming test for the existing height/width axes swap bug in DrawEllipse.

To run the tests:
```
bashcd imagelab-backend
uv sync --extra dev
uv run pytest tests/test_drawing_operators.py -v
```

Fixes #146 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

All tests pass locally via `uv run pytest tests/test_drawing_operators.py -v`.


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally