### PR TITLE
fix: remove invalid OpenCV constants from DistanceTransform and cleanup frontend block

### DIFF
--- a/imagelab-backend/app/operators/transformation/distance_transform.py
+++ b/imagelab-backend/app/operators/transformation/distance_transform.py
@@ -7,8 +7,6 @@ DISTANCE_TYPES = {
     "DIST_C": cv2.DIST_C,
     "DIST_L1": cv2.DIST_L1,
     "DIST_L2": cv2.DIST_L2,
-    "DIST_LABEL_PIXEL": cv2.DIST_L2,
-    "DIST_MASK_3": cv2.DIST_L2,
 }
 
 

--- a/imagelab-frontend/src/blocks/definitions/transformation.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/transformation.blocks.ts
@@ -1,20 +1,17 @@
 export const transformationBlocks = [
   {
     type: "transformation_distance",
-    message0: "Apply %1 distance with %2 depth",
+    message0: "Apply %1 distance transform",
     args0: [
       {
         type: "field_dropdown",
         name: "type",
         options: [
-          ["DISTC", "DIST_C"],
-          ["DISTL1", "DIST_L1"],
-          ["DISTL2", "DIST_L2"],
-          ["DISTLABEL_PIXEL", "DIST_LABEL_PIXEL"],
-          ["DISTMASK_3", "DIST_MASK_3"],
+          ["DIST_C", "DIST_C"],
+          ["DIST_L1", "DIST_L1"],
+          ["DIST_L2", "DIST_L2"],
         ],
       },
-      { type: "field_number", name: "ddepth", value: 0, min: -10, max: 10 },
     ],
     previousStatement: null,
     nextStatement: null,


### PR DESCRIPTION

## Description

Removes `DIST_LABEL_PIXEL` and `DIST_MASK_3` from the `DISTANCE_TYPES` dict in `distance_transform.py`. These are **not** valid distance type constants in OpenCV — they belong to the `DistanceLabelType` and `DistanceMaskSize` enum families respectively. Both were incorrectly mapped to `cv2.DIST_L2`, causing silently wrong output whenever a user selected either option from the dropdown.

Also removes the unused `ddepth` field from the frontend block definition since the backend never reads it for this operator.

Fixes #160

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass (`uv run pytest`)
- [ ] New tests added
- [x] Manual testing

Manual verification:
- Selected `DIST_C` → output correctly differs from `DIST_L2` (Chebyshev distance)
- Selected `DIST_L1` → output correctly differs from `DIST_L2` (Manhattan distance)
- Selected `DIST_L2` → standard Euclidean distance output unchanged
- Frontend block dropdown now shows only the 3 valid distance type options

## Screenshots (if applicable)

N/A — silent wrong output bug, no visual diff to show.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally