### PR TITLE
feat: add full-screen preview modal for Original and Processed images

### DIFF
--- a/imagelab-frontend/src/components/Preview/ImageDisplay.tsx
+++ b/imagelab-frontend/src/components/Preview/ImageDisplay.tsx
@@ -1,3 +1,6 @@
+import { useState } from "react";
+import ImageModal from "./ImageModal";
+
 interface ImageDisplayProps {
   image: string;
   format: string;
@@ -5,12 +8,23 @@ interface ImageDisplayProps {
 }
 
 export default function ImageDisplay({ image, format, zoomWidth }: ImageDisplayProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const imageSrc = `data:image/${format};base64,${image}`;
+
   return (
-    <img
-      src={`data:image/${format};base64,${image}`}
-      alt="Preview"
-      className={zoomWidth ? "" : "max-w-full max-h-full object-contain"}
-      style={zoomWidth ? { width: `${zoomWidth}px` } : undefined}
-    />
+    <>
+      <img
+        src={imageSrc}
+        alt="Preview"
+        className={
+          zoomWidth
+            ? "cursor-zoom-in"
+            : "max-w-full max-h-full object-contain cursor-zoom-in hover:opacity-90 transition-opacity"
+        }
+        style={zoomWidth ? { width: `${zoomWidth}px` } : undefined}
+        onClick={() => setIsModalOpen(true)}
+      />
+      <ImageModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} imageSrc={imageSrc} />
+    </>
   );
 }

--- a/imagelab-frontend/src/components/Preview/ImageModal.tsx
+++ b/imagelab-frontend/src/components/Preview/ImageModal.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { X } from "lucide-react";
+
+interface ImageModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  imageSrc: string;
+}
+
+export default function ImageModal({ isOpen, onClose, imageSrc }: ImageModalProps) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "auto";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 p-2 text-white/70 hover:text-white transition-colors bg-black/20 hover:bg-black/40 rounded-full"
+        aria-label="Close"
+      >
+        <X size={24} />
+      </button>
+
+      <div className="w-full h-full flex items-center justify-center p-4" onClick={onClose}>
+        <img
+          src={imageSrc}
+          alt="Full screen preview"
+          className="max-w-full max-h-full object-contain cursor-default"
+          onClick={(e) => e.stopPropagation()}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**## Description of Changes**

This PR introduces an interactive, high-resolution Image Modal that allows users to click on either their "Original" or "Processed" images inside the ImageLab workspace to view them in a full-screen, focused overlay.

Fix - #162 

**## Implementations**

1. **Added `ImageModal.tsx` Component:**
   - Designed a new lightweight React component responsible for rendering a fixed, full-screen dark backdrop overlay containing the selected image.
   - Includes accessibility and UX features: pressing the `Escape` key, clicking anywhere on the dark backdrop, or clicking the dedicated `X` close button will dismiss the modal.

2. **Updated `ImageDisplay.tsx` Component:**
   - Modified the core display component that manages both the Original and Processed images.
   - Introduced a new `isModalOpen` React state hook.
   - Wrapped the image in an interactive click handler that toggles the modal.
   - Added hover styles (`hover:opacity-90 transition-opacity` and `cursor-zoom-in`) so users intuitively know the image is clickable.
   - Integrated the `ImageModal` component directly alongside the main image thumbnail, passing it the appropriate Base64 resource string.

**## Testing Guidelines**

- Upload an image via the "Read Image" pipeline block. It should appear in the "Original" viewing pane.
- Hover over the image to view the new zoom-in cursor icon.
- Click on the image. A dark overlay component covering the workspace should appear rendering your source image.
- Dismiss the full-screen view (e.g., using `Escape`).
- Build a processing pipeline to create a new image in the "Processed" pane below.
- Verify clicking the resulting image also triggers the new modal preview overlay.

**## Result**

<img width="1918" height="907" alt="Screenshot 2026-03-10 231839" src="https://github.com/user-attachments/assets/121629d3-fc32-4e25-9b5f-b86c0259ab19" />

<img width="1918" height="883" alt="Screenshot 2026-03-10 231855" src="https://github.com/user-attachments/assets/b3aa2439-1a17-481b-9d61-8b92f6ba4229" />

<img width="1919" height="893" alt="Screenshot 2026-03-10 231917" src="https://github.com/user-attachments/assets/47fbd945-c98d-4456-a473-0bb4cc217905" />

