### PR TITLE
Fix OtsuThreshold crash on BGRA (4-channel) PNG input

### DIFF
--- a/imagelab-backend/app/operators/thresholding/otsu_threshold.py
+++ b/imagelab-backend/app/operators/thresholding/otsu_threshold.py
@@ -7,9 +7,11 @@ from app.operators.base import BaseOperator
 class OtsuThreshold(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         max_value = float(self.params.get("maxValue", 255))
-        # Convert to grayscale if not already
-        if len(image.shape) == 3:
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        if image.ndim == 3:
+            if image.shape[2] == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         _, image = cv2.threshold(
             image,
             0,

--- a/imagelab-backend/tests/test_thresholding_operators.py
+++ b/imagelab-backend/tests/test_thresholding_operators.py
@@ -117,6 +117,15 @@ class TestOtsuThreshold:
         assert len(result.shape) == 2
         assert set(np.unique(result)).issubset({0, 255})
 
+    def test_bgra_input_with_varying_alpha(self, color_image):
+        alpha = np.linspace(0, 255, color_image.shape[1], dtype=np.uint8)
+        alpha = np.tile(alpha, (color_image.shape[0], 1))
+        bgra = np.dstack([color_image, alpha])
+        result = OtsuThreshold({}).compute(bgra)
+        assert result.shape == color_image.shape[:2]
+        assert result.dtype == np.uint8
+        assert set(np.unique(result)).issubset({0, 255})
+
     def test_grayscale_input(self, grayscale_image):
         result = OtsuThreshold({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape


### PR DESCRIPTION
## Description

Fixes a crash in `OtsuThreshold` when the input is a BGRA (4-channel) PNG.

Changes made:
- Handle 4-channel input explicitly in `OtsuThreshold.compute`
- Convert BGRA input using `cv2.COLOR_BGRA2GRAY`
- Keep existing BGR-to-grayscale behavior for 3-channel images
- Add a regression test for BGRA input with varying alpha values

Fixes #176

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added a new unit test: `test_bgra_input_with_varying_alpha` in `imagelab-backend/tests/test_thresholding_operators.py`.

Local execution status in this environment:
- `python -m pytest imagelab-backend/tests/test_thresholding_operators.py -q` could not run because `cv2` is not installed (`ModuleNotFoundError: No module named 'cv2'`).

- [ ] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally