### PR TITLE
Fix ColorToBinary crash on grayscale input

### DIFF
--- a/imagelab-backend/app/operators/conversions/color_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/color_to_binary.py
@@ -15,11 +15,11 @@ class ColorToBinary(BaseOperator):
         threshold_type = THRESHOLD_TYPES.get(threshold_type_name, cv2.THRESH_BINARY)
         threshold_value = float(self.params.get("thresholdValue", 0))
         max_value = float(self.params.get("maxValue", 0))
-
-        if len(image.shape) == 3 and image.shape[2] == 4:
+        if image.ndim == 2:
+            gray = image
+        elif image.ndim == 3 and image.shape[2] == 4:
             gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
         else:
             gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-
         _, dst = cv2.threshold(gray, threshold_value, max_value, threshold_type)
         return dst

--- a/imagelab-backend/tests/test_conversion_operators.py
+++ b/imagelab-backend/tests/test_conversion_operators.py
@@ -113,6 +113,19 @@ class TestColorToBinary:
         result = ColorToBinary({"thresholdValue": 127, "maxValue": 255}).compute(color_image)
         assert result.dtype == np.uint8
 
+    def test_grayscale_input_does_not_crash(self, grayscale_image):
+        result = ColorToBinary({"thresholdValue": 127, "maxValue": 255}).compute(grayscale_image)
+        assert result.shape == grayscale_image.shape
+        assert result.dtype == np.uint8
+        assert set(np.unique(result)).issubset({0, 255})
+
+    def test_bgra_input_supported(self, color_image):
+        alpha = np.full(color_image.shape[:2], 255, dtype=np.uint8)
+        bgra = np.dstack([color_image, alpha])
+        result = ColorToBinary({"thresholdValue": 127, "maxValue": 255}).compute(bgra)
+        assert result.shape == color_image.shape[:2]
+        assert result.dtype == np.uint8
+
 
 # ColorMaps
 


### PR DESCRIPTION
## Description

Fix `ColorToBinary` crash when the input is already grayscale (single-channel).

Changes:
- Handle grayscale input directly without `cvtColor`
- Support BGRA input via `cv2.COLOR_BGRA2GRAY`
- Keep existing BGR behavior
- Add regression tests for grayscale and BGRA inputs

Fixes #178

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added tests in `imagelab-backend/tests/test_conversion_operators.py`:
- `test_grayscale_input_does_not_crash`
- `test_bgra_input_supported`

Local execution in this environment:
- `python -m pytest imagelab-backend/tests/test_conversion_operators.py -q` failed to start because `cv2` is not installed (`ModuleNotFoundError: No module named 'cv2'`).

- [ ] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally