### PR TITLE
Fix GrayToBinary default maxValue producing all-black output

### DIFF
--- a/imagelab-backend/app/operators/conversions/gray_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/gray_to_binary.py
@@ -7,6 +7,6 @@ from app.operators.base import BaseOperator
 class GrayToBinary(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         threshold_value = float(self.params.get("thresholdValue", 0))
-        max_value = float(self.params.get("maxValue", 0))
+        max_value = float(self.params.get("maxValue", 255))
         _, dst = cv2.threshold(image, threshold_value, max_value, cv2.THRESH_BINARY)
         return dst

--- a/imagelab-backend/tests/test_conversion_operators.py
+++ b/imagelab-backend/tests/test_conversion_operators.py
@@ -58,6 +58,13 @@ class TestGrayToBinary:
         result = GrayToBinary({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
 
+    def test_default_params_produce_non_black_output(self):
+        img = np.zeros((100, 100), dtype=np.uint8)
+        img[:50, :] = 50
+        img[50:, :] = 200
+        result = GrayToBinary({}).compute(img)
+        assert set(np.unique(result)) == {0, 255}
+
     def test_custom_threshold_output_shape(self, grayscale_image):
         result = GrayToBinary({"thresholdValue": 127, "maxValue": 255}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape

--- a/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
@@ -46,7 +46,7 @@ export const conversionsBlocks = [
     args0: [
       { type: "input_dummy" },
       { type: "field_number", name: "thresholdValue", value: 0, min: 0 },
-      { type: "field_number", name: "maxValue", value: 0, min: 0 },
+      { type: "field_number", name: "maxValue", value: 255, min: 0 },
     ],
     previousStatement: null,
     nextStatement: null,


### PR DESCRIPTION
## Description

Fixes `GrayToBinary` default behavior where `maxValue=0` caused all-black output.

Changes included:
- Backend: set `GrayToBinary` default `maxValue` from `0` to `255`
- Frontend block default: set `imageconvertions_graytobinary.maxValue` from `0` to `255`
- Added regression test to ensure default params produce binary output (`{0, 255}`)

Fixes #180

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- Local runtime verification script confirms `GrayToBinary({})` now returns values `[0, 255]`.
- Added test: `test_default_params_produce_non_black_output` in `imagelab-backend/tests/test_conversion_operators.py`.
- Full pytest suite was not run in this environment because `pytest` is not installed in the project venv.

- [ ] Existing tests pass
- [x] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally