### PR TITLE
fix: expose tx and ty translation params on AffineImage operator

### DIFF
--- a/imagelab-backend/app/operators/geometric/affine_image.py
+++ b/imagelab-backend/app/operators/geometric/affine_image.py
@@ -7,5 +7,7 @@ from app.operators.base import BaseOperator
 class AffineImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         rows, cols = image.shape[:2]
-        M = np.float64([[1, 0, 50], [0, 1, 100]])
+        tx = float(self.params.get("tx", 50))
+        ty = float(self.params.get("ty", 100))
+        M = np.float64([[1, 0, tx], [0, 1, ty]])
         return cv2.warpAffine(image, M, (cols, rows))

--- a/imagelab-backend/app/operators/geometric/affine_image.py
+++ b/imagelab-backend/app/operators/geometric/affine_image.py
@@ -1,3 +1,5 @@
+import math
+
 import cv2
 import numpy as np
 
@@ -5,9 +7,23 @@ from app.operators.base import BaseOperator
 
 
 class AffineImage(BaseOperator):
+    DEFAULT_TX = 50.0
+    DEFAULT_TY = 100.0
+
     def compute(self, image: np.ndarray) -> np.ndarray:
         rows, cols = image.shape[:2]
-        tx = float(self.params.get("tx", 50))
-        ty = float(self.params.get("ty", 100))
+
+        try:
+            tx = float(self.params.get("tx", self.DEFAULT_TX))
+            ty = float(self.params.get("ty", self.DEFAULT_TY))
+        except (TypeError, ValueError):
+            tx, ty = self.DEFAULT_TX, self.DEFAULT_TY
+
+        if not math.isfinite(tx) or not math.isfinite(ty):
+            tx, ty = self.DEFAULT_TX, self.DEFAULT_TY
+
+        tx = max(-cols, min(cols, tx))
+        ty = max(-rows, min(rows, ty))
+
         M = np.float64([[1, 0, tx], [0, 1, ty]])
         return cv2.warpAffine(image, M, (cols, rows))

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -96,11 +96,15 @@ export const geometricBlocks = [
   },
   {
     type: "geometric_affineimage",
-    message0: "Apply affine transformation",
+    message0: "Apply affine transformation | translate x %1 y %2",
+    args0: [
+      { type: "field_number", name: "tx", value: 50 },
+      { type: "field_number", name: "ty", value: 100 },
+    ],
     previousStatement: null,
     nextStatement: null,
     style: "geometric_style",
     tooltip:
-      "Applies a fixed affine transformation (translate by 50, 100) - Transforms the image using a predefined affine transformation that translates the image by 50 pixels in the X direction and 100 pixels in the Y direction. This block is useful for demonstrating basic affine transformations, which can include translation, rotation, scaling, and shearing.",
+      "Applies an affine transformation to the image - Translates the image by the specified number of pixels along the X and Y axes. Positive tx shifts the image right; positive ty shifts it down. Pixels shifted outside the image boundary are filled with black.",
   },
 ];

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -96,15 +96,17 @@ export const geometricBlocks = [
   },
   {
     type: "geometric_affineimage",
-    message0: "Apply affine transformation | translate x %1 y %2",
-    args0: [
-      { type: "field_number", name: "tx", value: 50 },
-      { type: "field_number", name: "ty", value: 100 },
+    message0: "Apply affine transformation %1",
+    args0: [{ type: "input_dummy" }],
+    message1: "translate x %1 y %2",
+    args1: [
+      { type: "field_number", name: "tx", value: 50, min: -10000, max: 10000, precision: 1 },
+      { type: "field_number", name: "ty", value: 100, min: -10000, max: 10000, precision: 1 },
     ],
     previousStatement: null,
     nextStatement: null,
     style: "geometric_style",
     tooltip:
-      "Applies an affine transformation to the image - Translates the image by the specified number of pixels along the X and Y axes. Positive tx shifts the image right; positive ty shifts it down. Pixels shifted outside the image boundary are filled with black.",
+      "Applies a 2×3 affine transformation matrix to warp the image. Currently exposes translation (tx, ty); the underlying transform supports rotation, scaling, and shearing. Positive tx shifts the image right; positive ty shifts it down. Pixels shifted outside the image boundary are filled with black.",
   },
 ];

--- a/imagelab-frontend/src/data/operatorDocs.ts
+++ b/imagelab-frontend/src/data/operatorDocs.ts
@@ -69,14 +69,21 @@ export const operatorDocs: Record<string, OperatorDoc> = {
   },
   geometric_affineimage: {
     name: "Affine Transform",
-    description: "Applies a 2x3 affine transformation matrix to warp the image.",
+    description: "Applies a 2x3 affine transformation matrix to translate the image.",
     parameters: [
       {
-        name: "Points",
-        description: "Three points in the original image mapped to three points in the output.",
+        name: "Translate X (tx)",
+        description: "Horizontal translation in pixels. Positive values shift the image right.",
+      },
+      {
+        name: "Translate Y (ty)",
+        description: "Vertical translation in pixels. Positive values shift the image down.",
       },
     ],
-    useCases: ["Perspective correction, scaling, and skewing."],
+    useCases: [
+      "Shifting an image to correct alignment or framing.",
+      "Demonstrating translation as a basic affine transformation.",
+    ],
   },
   geometric_scaleimage: {
     name: "Scale Image",


### PR DESCRIPTION
## Description
Exposes `tx` and `ty` translation parameters on the AffineImage operator, replacing the hardcoded `M = np.float64([[1, 0, 50], [0, 1, 100]])` matrix. The frontend block now shows two number fields for X and Y translation. The backend reads these params to construct the transformation matrix at runtime. Default values of `tx=50, ty=100` preserve the previous behaviour. `operatorDocs.ts` updated to document the new parameters.

Fixes #191 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran the pipeline with the AffineImage block at various `tx`/`ty` values and confirmed the image shifts correctly in both axes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally