### PR TITLE
feat: add pre-run pipeline validation warnings

### DIFF
--- a/imagelab-frontend/src/components/PipelineWarningsModal.tsx
+++ b/imagelab-frontend/src/components/PipelineWarningsModal.tsx
@@ -1,0 +1,97 @@
+import { AlertTriangle, X, Play } from "lucide-react";
+import type { ValidationWarning } from "../utils/pipelineValidation";
+
+interface PipelineWarningsModalProps {
+  warnings: ValidationWarning[];
+  onRunAnyway: () => void;
+  onCancel: () => void;
+}
+
+export default function PipelineWarningsModal({
+  warnings,
+  onRunAnyway,
+  onCancel,
+}: PipelineWarningsModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Pipeline Warnings"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={18} className="text-amber-500" />
+            <h2 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
+              Pipeline Warnings
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+            title="Close"
+            aria-label="Close"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Warnings list */}
+        <div className="p-5 space-y-3 max-h-72 overflow-y-auto">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            The following issues were detected before running. You can fix them or run anyway.
+          </p>
+          <ul className="space-y-2">
+            {warnings.map((w, idx) => (
+              <li
+                key={idx}
+                className="flex gap-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+              >
+                <AlertTriangle
+                  size={14}
+                  className="text-amber-500 flex-shrink-0 mt-0.5"
+                  aria-hidden="true"
+                />
+                <div className="flex flex-col gap-0.5">
+                  {w.step > 0 && (
+                    <span className="text-[10px] font-semibold text-amber-600 dark:text-amber-400 uppercase tracking-wide">
+                      Step {w.step}
+                    </span>
+                  )}
+                  <span className="text-xs text-amber-800 dark:text-amber-200">{w.message}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 px-5 py-4 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 py-2 px-3 rounded-lg text-sm font-medium border border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onRunAnyway}
+            className="flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 transition-colors"
+          >
+            <Play size={14} aria-hidden="true" />
+            Run Anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -5,7 +5,10 @@ import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { validatePipeline } from "../utils/pipelineValidation";
+import type { ValidationWarning } from "../utils/pipelineValidation";
 import SharePipelineModal from "./SharePipelineModal";
+import PipelineWarningsModal from "./PipelineWarningsModal";
 
 interface ToolbarProps {
   workspace: Blockly.WorkspaceSvg | null;
@@ -34,6 +37,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
+  const [pendingWarnings, setPendingWarnings] = useState<ValidationWarning[] | null>(null);
 
   const handleNew = () => {
     if (!window.confirm("This will clear all blocks and the uploaded image. Continue?")) {
@@ -54,7 +58,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   const handleUndo = () => workspace?.undo(false);
   const handleRedo = () => workspace?.undo(true);
 
-  const handleRun = async () => {
+  const doExecute = async () => {
     if (!workspace || !originalImage) return;
 
     const pipeline = extractPipeline(workspace);
@@ -87,6 +91,37 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     } finally {
       setExecuting(false);
     }
+  };
+
+  const handleRun = async () => {
+    if (!workspace || !originalImage) return;
+
+    const pipeline = extractPipeline(workspace);
+    if (pipeline.length === 0) {
+      setError('No pipeline found. Add a "Read Image" block and connect operations.');
+      return;
+    }
+
+    // Filter out the missing Write Image warning — informational only, not a blocker
+    const warnings = validatePipeline(pipeline).filter(
+      (w) => w.operatorType !== "basic_writeimage",
+    );
+
+    if (warnings.length > 0) {
+      setPendingWarnings(warnings);
+      return;
+    }
+
+    await doExecute();
+  };
+
+  const handleRunAnyway = async () => {
+    setPendingWarnings(null);
+    await doExecute();
+  };
+
+  const handleCancelWarnings = () => {
+    setPendingWarnings(null);
   };
 
   // Register global keyboard shortcuts
@@ -204,6 +239,14 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
       {showShareModal && (
         <SharePipelineModal workspace={workspace} onClose={() => setShowShareModal(false)} />
+      )}
+
+      {pendingWarnings && (
+        <PipelineWarningsModal
+          warnings={pendingWarnings}
+          onRunAnyway={handleRunAnyway}
+          onCancel={handleCancelWarnings}
+        />
       )}
     </>
   );

--- a/imagelab-frontend/src/utils/pipelineValidation.ts
+++ b/imagelab-frontend/src/utils/pipelineValidation.ts
@@ -1,0 +1,128 @@
+import type { PipelineStep } from "../types/pipeline";
+
+export interface ValidationWarning {
+  step: number;
+  operatorType: string;
+  message: string;
+}
+
+// Operators that require a grayscale (single-channel) input
+const REQUIRES_GRAYSCALE = new Set([
+  "imageconvertions_graytobinary",
+  "thresholding_applythreshold",
+  "thresholding_adaptivethreshold",
+  "thresholding_otsuthreshold",
+  "transformation_distance",
+]);
+
+// Operators that require a colour (3-channel BGR) input
+const REQUIRES_COLOR = new Set([
+  "imageconvertions_bgrtohsv",
+  "imageconvertions_bgrtolab",
+  "imageconvertions_bgrtoycrcb",
+  "imageconvertions_colortobinary",
+  "segmentation_watershed",
+  "segmentation_kmeans",
+  "segmentation_meanshift",
+]);
+
+// Operators that output grayscale
+const OUTPUTS_GRAYSCALE = new Set([
+  "imageconvertions_grayimage",
+  "imageconvertions_graytobinary",
+  "imageconvertions_colortobinary",
+  "imageconvertions_channelsplit",
+  "thresholding_applythreshold",
+  "thresholding_adaptivethreshold",
+  "thresholding_otsuthreshold",
+  "transformation_distance",
+  "sobelderivatives_soblederivate",
+  "sobelderivatives_scharrderivate",
+  "sobelderivatives_robertscross",
+  "filtering_cannyedge",
+]);
+
+// Operators that output colour
+const OUTPUTS_COLOR = new Set([
+  "basic_readimage",
+  "imageconvertions_clahe",
+  "imageconvertions_colormaps",
+  "imageconvertions_hsvtobgr",
+  "imageconvertions_labtobgr",
+  "imageconvertions_ycrcbtobgr",
+  "segmentation_watershed",
+  "segmentation_kmeans",
+  "segmentation_meanshift",
+]);
+
+type ChannelState = "color" | "grayscale" | "unknown";
+
+function friendlyName(operatorType: string): string {
+  const suffix = operatorType.includes("_")
+    ? operatorType.split("_").slice(1).join(" ")
+    : operatorType;
+  return suffix.replace(/([a-z])([A-Z])/g, "$1 $2");
+}
+
+export function validatePipeline(pipeline: PipelineStep[]): ValidationWarning[] {
+  const warnings: ValidationWarning[] = [];
+  let channelState: ChannelState = "unknown";
+
+  pipeline.forEach((step, index) => {
+    const stepNumber = index + 1;
+    const type = step.type;
+
+    // Skip read/write blocks from channel incompatibility checks
+    if (type === "basic_readimage") {
+      channelState = "color";
+      return;
+    }
+    if (type === "basic_writeimage") return;
+
+    // Check incompatibilities based on current channel state
+    if (channelState === "grayscale" && REQUIRES_COLOR.has(type)) {
+      warnings.push({
+        step: stepNumber,
+        operatorType: type,
+        message: `"${friendlyName(type)}" expects a colour image but the previous step outputs grayscale. This will likely cause an error at runtime.`,
+      });
+    }
+
+    if (channelState === "color" && REQUIRES_GRAYSCALE.has(type)) {
+      warnings.push({
+        step: stepNumber,
+        operatorType: type,
+        message: `"${friendlyName(type)}" expects a grayscale image but the previous step outputs colour. Add a Gray Image block before this step.`,
+      });
+    }
+
+    // Update channel state based on this step's output
+    if (OUTPUTS_GRAYSCALE.has(type)) {
+      channelState = "grayscale";
+    } else if (OUTPUTS_COLOR.has(type)) {
+      channelState = "color";
+    }
+  });
+
+  // Warn if pipeline has no Read Image block
+  const hasReadImage = pipeline.some((s) => s.type === "basic_readimage");
+  if (!hasReadImage) {
+    warnings.push({
+      step: 0,
+      operatorType: "basic_readimage",
+      message: 'No "Read Image" block found. The pipeline will not execute.',
+    });
+  }
+
+  // Warn if pipeline has no Write Image block
+  const hasWriteImage = pipeline.some((s) => s.type === "basic_writeimage");
+  if (!hasWriteImage) {
+    warnings.push({
+      step: pipeline.length,
+      operatorType: "basic_writeimage",
+      message: 'No "Write Image" block found. The processed image will not be saved to disk.',
+    });
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Description
Adds a pre-run pipeline validation pass that checks for known operator incompatibilities before sending the pipeline to the backend. A new `validatePipeline` utility walks the pipeline steps tracking channel state (colour vs grayscale) and flags operators that will likely fail given their input. Warnings are shown in a `PipelineWarningsModal` with a Cancel / Run Anyway choice so the check is never a hard blocker.

Fixes #197 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Tested the following cases manually: grayscale operator into a colour-only block, colour image into a grayscale-only block, missing Read Image block, and a valid pipeline with no warnings (runs immediately without showing the modal).

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
<img width="1398" height="750" alt="Screenshot 2026-03-12 at 9 17 03 PM" src="https://github.com/user-attachments/assets/6b9148f5-2231-4e13-968e-a932bfdda0fc" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally