### PR TITLE
feat: show pipeline step count in Toolbar stats

### DIFF
--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -65,7 +65,6 @@ export default function Toolbar({ workspace }: ToolbarProps) {
       return;
     }
 
-    setPipelineStepCount(pipeline.length);
     setExecuting(true);
     setError(null);
     setTiming(null);
@@ -80,11 +79,14 @@ export default function Toolbar({ workspace }: ToolbarProps) {
       setTiming(response.timings ?? null);
 
       if (response.success && response.image) {
+        setPipelineStepCount(pipeline.length);
         setProcessedImage(response.image);
       } else {
+        setPipelineStepCount(0);
         setError(response.error || "Pipeline execution failed", response.step);
       }
     } catch (err) {
+      setPipelineStepCount(0);
       setError(err instanceof Error ? err.message : "Network error");
       setTiming(null);
     } finally {
@@ -152,10 +154,8 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           {isExecuting ? "Running..." : "Run"}
         </button>
 
-        {/* Spacer to push stats to the right */}
         <div className="flex-1" />
 
-        {/* Live Statistics Display */}
         {blockCount > 0 && (
           <div className="relative group cursor-help px-2 flex items-center h-full border-l border-gray-100 ml-2">
             <div className="flex flex-col items-end leading-tight">
@@ -202,7 +202,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
               </div>
               {pipelineStepCount > 0 && (
                 <div className="mt-1.5 flex justify-between items-center text-gray-500 text-[10px] uppercase">
-                  <span>Pipeline Steps</span>
+                  <span>Last Run Steps</span>
                   <span className="font-bold text-gray-700 bg-gray-100 px-1.5 py-0.5 rounded">
                     {pipelineStepCount}
                   </span>

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -31,6 +31,8 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     uniqueBlockTypes,
     categoryCounts,
     complexity,
+    pipelineStepCount,
+    setPipelineStepCount,
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
@@ -63,6 +65,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
       return;
     }
 
+    setPipelineStepCount(pipeline.length);
     setExecuting(true);
     setError(null);
     setTiming(null);
@@ -197,6 +200,14 @@ export default function Toolbar({ workspace }: ToolbarProps) {
                   {uniqueBlockTypes}
                 </span>
               </div>
+              {pipelineStepCount > 0 && (
+                <div className="mt-1.5 flex justify-between items-center text-gray-500 text-[10px] uppercase">
+                  <span>Pipeline Steps</span>
+                  <span className="font-bold text-gray-700 bg-gray-100 px-1.5 py-0.5 rounded">
+                    {pipelineStepCount}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -13,14 +13,11 @@ interface PipelineState {
   selectedBlockType: string | null;
   selectedBlockTooltip: string | null;
   timings: PipelineTimings | null;
-
-  // Statistics
   blockCount: number;
   uniqueBlockTypes: number;
   categoryCounts: Record<string, number>;
   complexity: "Low" | "Medium" | "High";
   pipelineStepCount: number;
-
   setOriginalImage: (image: string, format: string) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
@@ -71,7 +68,8 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   setSelectedBlock: (type, tooltip) =>
     set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
   setTiming: (timings) => set({ timings }),
-  setPipelineStepCount: (count) => set({ pipelineStepCount: count }),
+  setPipelineStepCount: (count) =>
+    set({ pipelineStepCount: Number.isFinite(count) && count >= 0 ? count : 0 }),
   _imageResetFn: null as (() => void) | null,
   registerImageReset: (fn) => set({ _imageResetFn: fn }),
   clearImage: () => {
@@ -83,6 +81,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       error: null,
       errorStep: null,
       timings: null,
+      pipelineStepCount: 0,
     });
   },
   updateBlockStats: (workspace) => {

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -19,12 +19,15 @@ interface PipelineState {
   uniqueBlockTypes: number;
   categoryCounts: Record<string, number>;
   complexity: "Low" | "Medium" | "High";
+  pipelineStepCount: number;
+
   setOriginalImage: (image: string, format: string) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
   setError: (error: string | null, step?: number | null) => void;
   setSelectedBlock: (type: string | null, tooltip: string | null) => void;
   setTiming: (timings: PipelineTimings | null) => void;
+  setPipelineStepCount: (count: number) => void;
   updateBlockStats: (workspace: Blockly.WorkspaceSvg) => void;
   reset: () => void;
   clearImage: () => void;
@@ -53,6 +56,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   uniqueBlockTypes: 0,
   categoryCounts: {},
   complexity: "Low",
+  pipelineStepCount: 0,
   setOriginalImage: (image, format) =>
     set({
       originalImage: image,
@@ -67,6 +71,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   setSelectedBlock: (type, tooltip) =>
     set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
   setTiming: (timings) => set({ timings }),
+  setPipelineStepCount: (count) => set({ pipelineStepCount: count }),
   _imageResetFn: null as (() => void) | null,
   registerImageReset: (fn) => set({ _imageResetFn: fn }),
   clearImage: () => {
@@ -120,6 +125,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       uniqueBlockTypes: 0,
       categoryCounts: {},
       complexity: "Low",
+      pipelineStepCount: 0,
       timings: null,
     }),
 }));


### PR DESCRIPTION
## Description
Adds a Pipeline Steps counter to the Toolbar stats hover dropdown. A new `pipelineStepCount` field and `setPipelineStepCount` setter are added to `pipelineStore`. In `handleRun`, after `extractPipeline` is called, `setPipelineStepCount(pipeline.length)` is called to store the count. The Toolbar dropdown then renders a Pipeline Steps row beneath the existing Unique Types row, visible only after the first run.

Fixes #202 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Built pipelines with and without disconnected floating blocks and confirmed Pipeline Steps reflects only the connected chain. Confirmed the row is hidden before the first run and resets to hidden after clearing the workspace.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally