### PR TITLE
Feature: prewitt operator

### DIFF
--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -47,6 +47,7 @@ from app.operators.geometric.scale_image import ScaleImage
 from app.operators.segmentation.kmeans_segmentation import KMeansSegmentation
 from app.operators.segmentation.mean_shift_segmentation import MeanShiftSegmentation
 from app.operators.segmentation.watershed import Watershed
+from app.operators.sobel_derivatives.prewitt_operator import PrewittOperator
 from app.operators.sobel_derivatives.scharr_derivative import ScharrDerivative
 from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
 from app.operators.thresholding.adaptive_threshold import AdaptiveThreshold
@@ -117,6 +118,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     # Sobel Derivatives
     "sobelderivatives_soblederivate": SobelDerivative,
     "sobelderivatives_scharrderivate": ScharrDerivative,
+    "sobelderivatives_prewittoperator": PrewittOperator,
     # Transformation
     "transformation_distance": DistanceTransform,
     "transformation_laplacian": Laplacian,

--- a/imagelab-backend/app/operators/sobel_derivatives/prewitt_operator.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/prewitt_operator.py
@@ -4,19 +4,54 @@ import numpy as np
 from app.operators.base import BaseOperator
 
 _KERNEL_X = np.array([[-1, 0, 1], [-1, 0, 1], [-1, 0, 1]], dtype=np.float64)
+_KERNEL_X.flags.writeable = False
+
 _KERNEL_Y = np.array([[-1, -1, -1], [0, 0, 0], [1, 1, 1]], dtype=np.float64)
+_KERNEL_Y.flags.writeable = False
 
 
 class PrewittOperator(BaseOperator):
-    """Applies the Prewitt operator to detect edges using horizontal and vertical gradient kernels."""
+    """Applies the Prewitt operator to detect edges using horizontal and vertical gradient kernels.
+
+    Note:
+        Colour images are expected in BGR channel order (OpenCV convention).
+        Grayscale images must be 2-D arrays of dtype uint8.
+    """
 
     def compute(self, image: np.ndarray) -> np.ndarray:
+        """Compute the Prewitt gradient magnitude.
+
+        Args:
+            image: uint8 ndarray of shape (H, W), (H, W, 1), (H, W, 3), or (H, W, 4)
+                   in BGR channel order.
+
+        Returns:
+            uint8 ndarray of shape (H, W) containing gradient magnitudes
+            clipped to [0, 255].
+
+        Raises:
+            ValueError: If ``image.dtype`` is not ``np.uint8``.
+        """
         if image.dtype != np.uint8:
             raise ValueError(f"PrewittOperator expects a uint8 image, got dtype={image.dtype}.")
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
+
+        if image.ndim == 2:
+            gray = image
+        elif image.ndim == 3:
+            channels = image.shape[2]
+            if channels == 3:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            elif channels == 4:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            elif channels == 1:
+                gray = image[:, :, 0]
+            else:
+                raise ValueError(f"PrewittOperator expects 1, 3, or 4 channels, got shape={image.shape}.")
+        else:
+            raise ValueError(f"PrewittOperator expects a 2-D or 3-D array, got ndim={image.ndim}.")
 
         grad_x = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_X)
         grad_y = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_Y)
 
-        magnitude = np.sqrt(grad_x**2 + grad_y**2)
-        return np.clip(magnitude, 0, 255).astype(np.uint8)
+        magnitude = np.hypot(grad_x, grad_y)
+        return np.minimum(magnitude, 255).astype(np.uint8)

--- a/imagelab-backend/app/operators/sobel_derivatives/prewitt_operator.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/prewitt_operator.py
@@ -1,0 +1,22 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+_KERNEL_X = np.array([[-1, 0, 1], [-1, 0, 1], [-1, 0, 1]], dtype=np.float64)
+_KERNEL_Y = np.array([[-1, -1, -1], [0, 0, 0], [1, 1, 1]], dtype=np.float64)
+
+
+class PrewittOperator(BaseOperator):
+    """Applies the Prewitt operator to detect edges using horizontal and vertical gradient kernels."""
+
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if image.dtype != np.uint8:
+            raise ValueError(f"PrewittOperator expects a uint8 image, got dtype={image.dtype}.")
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
+
+        grad_x = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_X)
+        grad_y = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_Y)
+
+        magnitude = np.sqrt(grad_x**2 + grad_y**2)
+        return np.clip(magnitude, 0, 255).astype(np.uint8)

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -145,6 +145,7 @@ export const categories: CategoryInfo[] = [
     blocks: [
       { type: "sobelderivatives_soblederivate", label: "Sobel Derivative" },
       { type: "sobelderivatives_scharrderivate", label: "Scharr Derivative" },
+      { type: "sobelderivatives_prewittoperator", label: "Prewitt Operator" },
     ],
   },
   {

--- a/imagelab-frontend/src/blocks/definitions/sobel-derivatives.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/sobel-derivatives.blocks.ts
@@ -38,4 +38,13 @@ export const sobelDerivativesBlocks = [
     tooltip:
       "Detect edges using Scharr derivative (first order) - Applies the Scharr operator, which is a more accurate first-order derivative operator than Sobel due to its optimized kernel weights. The 'type' parameter specifies the direction: 'Horizontal' detects vertical edges and 'Vertical' detects horizontal edges. The output is always a uint8 image.",
   },
+  {
+    type: "sobelderivatives_prewittoperator",
+    message0: "Apply Prewitt edge detection",
+    previousStatement: null,
+    nextStatement: null,
+    style: "sobel_derivatives_style",
+    tooltip:
+      "Detect edges using the Prewitt operator - Applies two 3x3 kernels to compute horizontal and vertical gradient magnitude. Similar to Sobel but with equal weights across all rows/columns, making it slightly simpler and faster. Colour images are converted to grayscale automatically.",
+  },
 ];

--- a/imagelab-frontend/src/data/operatorDocs.ts
+++ b/imagelab-frontend/src/data/operatorDocs.ts
@@ -418,6 +418,18 @@ export const operatorDocs: Record<string, OperatorDoc> = {
       "Fine-grained edge detection on medical or scientific images requiring higher rotational symmetry than Sobel.",
     ],
   },
+  sobelderivatives_prewittoperator: {
+    name: "Prewitt Operator",
+    description:
+      "Applies the Prewitt operator to detect edges using two 3x3 gradient kernels. Similar to Sobel but uses equal weights, making it a simpler approximation of the image gradient.",
+    parameters: [],
+    formula: "G = √(Gx² + Gy²), Gx = [[-1,0,1],[-1,0,1],[-1,0,1]], Gy = Gx^T",
+    useCases: [
+      "Teaching the difference between equally-weighted (Prewitt) and distance-weighted (Sobel) gradient operators.",
+      "Fast edge detection where equal directional sensitivity is preferred.",
+      "Comparing classical edge detectors side-by-side in an educational pipeline.",
+    ],
+  },
 
   // --- Transformation ---
   transformation_distance: {


### PR DESCRIPTION
## Description
Adds a Prewitt edge detection operator to the Sobel Derivatives category. The backend applies two 3x3 gradient kernels (`Gx = [[-1,0,1],[-1,0,1],[-1,0,1]]`, `Gy = Gx^T`) via `cv2.filter2D` and returns the gradient magnitude as a uint8 image. Colour images are automatically converted to grayscale.

Fixes #204 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran the pipeline with a Prewitt block on both grayscale and colour images and confirmed correct edge detection output. Compared output against Sobel to verify expected differences in edge strength and weight distribution.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally