### PR TITLE
feat: add keyboard shortcut help modal

### DIFF
--- a/imagelab-frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/imagelab-frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,4 +1,5 @@
 import { X, Keyboard } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 interface KeyboardShortcutsModalProps {
   onClose: () => void;
@@ -33,24 +34,49 @@ const SHORTCUTS = [
 ];
 
 export default function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
       onClick={onClose}
-      role="presentation"
+      role="none"
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-label="Keyboard Shortcuts"
-        className="bg-white rounded-xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden"
+        aria-labelledby="shortcuts-modal-title"
+        tabIndex={-1}
+        className="bg-white rounded-xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden outline-none"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
           <div className="flex items-center gap-2">
             <Keyboard size={16} className="text-gray-500" />
-            <h2 className="text-sm font-semibold text-gray-800">Keyboard Shortcuts</h2>
+            <h2 id="shortcuts-modal-title" className="text-sm font-semibold text-gray-800">
+              Keyboard Shortcuts
+            </h2>
           </div>
           <button
             type="button"
@@ -63,7 +89,6 @@ export default function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsMod
           </button>
         </div>
 
-        {/* Shortcuts list */}
         <div className="p-5 space-y-5">
           {SHORTCUTS.map((group) => (
             <div key={group.category}>

--- a/imagelab-frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/imagelab-frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,96 @@
+import { X, Keyboard } from "lucide-react";
+
+interface KeyboardShortcutsModalProps {
+  onClose: () => void;
+}
+
+const isMac =
+  typeof navigator !== "undefined" && /mac/i.test(navigator.platform || navigator.userAgent);
+const mod = isMac ? "⌘" : "Ctrl";
+
+const SHORTCUTS = [
+  {
+    category: "Pipeline",
+    items: [
+      { keys: [mod, "Enter"], description: "Run pipeline" },
+      { keys: [mod, "S"], description: "Download processed image" },
+    ],
+  },
+  {
+    category: "Edit",
+    items: [
+      { keys: [mod, "Z"], description: "Undo" },
+      { keys: [mod, "⇧Z"], description: "Redo" },
+      { keys: [mod, "Y"], description: "Redo (alternative)" },
+      { keys: ["Delete"], description: "Remove selected block" },
+      { keys: ["Backspace"], description: "Remove selected block" },
+    ],
+  },
+  {
+    category: "Help",
+    items: [{ keys: ["⇧", "?"], description: "Open this shortcuts panel" }],
+  },
+];
+
+export default function KeyboardShortcutsModal({ onClose }: KeyboardShortcutsModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard Shortcuts"
+        className="bg-white rounded-xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-2">
+            <Keyboard size={16} className="text-gray-500" />
+            <h2 className="text-sm font-semibold text-gray-800">Keyboard Shortcuts</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+            title="Close"
+            aria-label="Close"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Shortcuts list */}
+        <div className="p-5 space-y-5">
+          {SHORTCUTS.map((group) => (
+            <div key={group.category}>
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+                {group.category}
+              </div>
+              <div className="space-y-2">
+                {group.items.map((shortcut, idx) => (
+                  <div key={idx} className="flex items-center justify-between">
+                    <span className="text-xs text-gray-600">{shortcut.description}</span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key, ki) => (
+                        <span
+                          key={ki}
+                          className="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-1.5 rounded bg-gray-100 border border-gray-300 text-[11px] font-medium text-gray-700 font-mono shadow-sm"
+                        >
+                          {key}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import * as Blockly from "blockly";
-import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2 } from "lucide-react";
+import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Keyboard } from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import SharePipelineModal from "./SharePipelineModal";
+import KeyboardShortcutsModal from "./KeyboardShortcutsModal";
 
 interface ToolbarProps {
   workspace: Blockly.WorkspaceSvg | null;
@@ -34,6 +35,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showShortcutsModal, setShowShortcutsModal] = useState(false);
 
   const handleNew = () => {
     if (!window.confirm("This will clear all blocks and the uploaded image. Continue?")) {
@@ -89,6 +91,18 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     }
   };
 
+  // Shift+? opens the shortcuts modal
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "?" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        setShowShortcutsModal((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   // Register global keyboard shortcuts
   useKeyboardShortcuts({
     onRun: handleRun,
@@ -137,13 +151,21 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           <Share2 size={18} />
         </button>
 
+        <button
+          onClick={() => setShowShortcutsModal(true)}
+          className={iconBtn}
+          title="Keyboard Shortcuts (⇧?)"
+        >
+          <Keyboard size={18} />
+        </button>
+
         <div className={separator} />
 
         <button
           onClick={handleRun}
           disabled={isExecuting || !originalImage}
           className="flex items-center gap-1.5 px-3 py-1 rounded-md text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          title="Run Pipeline"
+          title={`Run Pipeline (${mod}Enter)`}
         >
           {isExecuting ? <Loader2 size={16} className="animate-spin" /> : <Play size={16} />}
           {isExecuting ? "Running..." : "Run"}
@@ -204,6 +226,10 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
       {showShareModal && (
         <SharePipelineModal workspace={workspace} onClose={() => setShowShareModal(false)} />
+      )}
+
+      {showShortcutsModal && (
+        <KeyboardShortcutsModal onClose={() => setShowShortcutsModal(false)} />
       )}
     </>
   );

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -95,8 +95,15 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "?" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        const target = e.target as HTMLElement;
+        const isEditable =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          target instanceof HTMLSelectElement ||
+          target.isContentEditable;
+        if (isEditable) return;
         e.preventDefault();
-        setShowShortcutsModal((prev) => !prev);
+        setShowShortcutsModal(true);
       }
     };
     window.addEventListener("keydown", handler);


### PR DESCRIPTION
## Description
Adds a keyboard shortcut help modal to the Toolbar. A new `KeyboardShortcutsModal` component lists all shortcuts grouped by category (Pipeline, Edit, Help) with styled key badge display. The modal can be opened via a `Keyboard` icon button added to the Toolbar next to the Share button, or by pressing `Shift+?` from anywhere in the app. A `useEffect` in Toolbar registers the `Shift+?` listener independently of the existing `useKeyboardShortcuts` hook so no existing shortcut behaviour is changed. The Run button tooltip is also updated to include the `Cmd/Ctrl+Enter` hint.


Fixes #207 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Confirmed the modal opens and closes via the Toolbar button, via `Shift+?`, and via the backdrop click. Verified all shortcuts are listed correctly for both macOS and non-macOS. Confirmed `Shift+?` does not fire when typing in a Blockly field.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 
<img width="1397" height="762" alt="key sc" src="https://github.com/user-attachments/assets/15d11757-1bb9-4c13-823f-abcd039dc70d" />


## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally