### PR TITLE
fix(filtering): correct swapped width/height kernel size in BoxFilter

### DIFF
--- a/imagelab-backend/app/operators/filtering/box_filter.py
+++ b/imagelab-backend/app/operators/filtering/box_filter.py
@@ -1,6 +1,5 @@
 import cv2
 import numpy as np
-
 from app.operators.base import BaseOperator
 
 
@@ -14,7 +13,7 @@ class BoxFilter(BaseOperator):
         return cv2.boxFilter(
             image,
             depth,
-            (height, width),
+            (width, height),  # OpenCV ksize convention: (width, height)
             anchor=(point_x, point_y),
             normalize=True,
             borderType=cv2.BORDER_DEFAULT,

--- a/imagelab-backend/app/operators/filtering/box_filter.py
+++ b/imagelab-backend/app/operators/filtering/box_filter.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+
 from app.operators.base import BaseOperator
 
 

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -1,3 +1,4 @@
+import cv2
 import numpy as np
 import pytest
 
@@ -74,6 +75,24 @@ class TestBoxFilter:
     def test_output_is_uint8(self, color_image):
         result = BoxFilter({"depth": -1}).compute(color_image)
         assert result.dtype == np.uint8
+
+    def test_asymmetric_kernel_uses_width_height_convention(self):
+        image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
+        width, height = 1, 5
+
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
+            image
+        )
+        expected = cv2.boxFilter(
+            image,
+            -1,
+            (width, height),
+            anchor=(-1, -1),
+            normalize=True,
+            borderType=cv2.BORDER_DEFAULT,
+        )
+
+        np.testing.assert_array_equal(result, expected)
 
 
 # Sharpen


### PR DESCRIPTION
## Description

Fixed `BoxFilter` silently applying a transposed kernel for non-square kernel sizes.

`cv2.boxFilter()` expects `ksize` as `(width, height)`, but the implementation
passed `(height, width)`. For square kernels (`width == height`) this had no
visible effect; for asymmetric kernels the wrong axis was smoothed.

This issue was identified while checking operator consistency after the earlier
Blur operator fix.

Fixes #216

## Impact

- Non-square kernels (`width != height`): output now changes to the correct result
- Square kernels (`width == height`): no behavior change

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Manual verification against OpenCV's documented `ksize` convention
- Added an automated regression test for the asymmetric-kernel case
- Ran:

```bash
python -m pytest imagelab-backend/tests/test_filtering_operators.py
python -m py_compile imagelab-backend/app/operators/filtering/box_filter.py imagelab-backend/tests/test_filtering_operators.py