### PR TITLE
feat: add TIFF, WebP, BMP input format support with validation

### DIFF
--- a/imagelab-backend/app/utils/image.py
+++ b/imagelab-backend/app/utils/image.py
@@ -13,8 +13,16 @@ def decode_base64_image(b64: str) -> np.ndarray:
     return image
 
 
+SUPPORTED_FORMATS = {"png", "jpg", "jpeg", "webp", "bmp", "tiff", "tif"}
+FORMAT_ALIASES = {"jpg": "jpeg", "tif": "tiff"}
+
+
 def encode_image_base64(image: np.ndarray, fmt: str = "png") -> str:
-    success, buf = cv2.imencode(f".{fmt}", image)
+    fmt = fmt.lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(f"Unsupported image format: {fmt!r}. Supported: {sorted(SUPPORTED_FORMATS)}")
+    ext = FORMAT_ALIASES.get(fmt, fmt)
+    success, buf = cv2.imencode(f".{ext}", image)
     if not success:
-        raise ValueError(f"Could not encode image as {fmt}")
+        raise ValueError(f"Could not encode image as {ext}")
     return base64.b64encode(buf).decode("utf-8")


### PR DESCRIPTION
## Description
Adds format validation and alias normalisation to `encode_image_base64` in `app/utils/image.py`. Previously, unsupported or aliased format strings were passed directly to `cv2.imencode`, causing silent failures or cryptic errors. This introduces a `SUPPORTED_FORMATS` set and `FORMAT_ALIASES` map so aliases are resolved before encoding and unsupported formats raise a descriptive `ValueError` immediately.

Fixes #227 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran the existing test suite to confirm no regressions.
- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally