### PR TITLE
feat: add drag-and-drop and clipboard paste image upload

### DIFF
--- a/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
+++ b/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
@@ -1,8 +1,8 @@
 import * as Blockly from "blockly";
 import { usePipelineStore } from "../../store/pipelineStore";
+import { loadImageFile } from "../../hooks/useImageUpload";
 
 function initReadImageBlock(block: Blockly.Block) {
-  // Skip interactive setup in readOnly workspaces (e.g. sidebar previews)
   if (block.workspace.options?.readOnly) return;
 
   const fileInput = document.createElement("input");
@@ -15,23 +15,14 @@ function initReadImageBlock(block: Blockly.Block) {
     const file = fileInput.files?.[0];
     if (!file) return;
 
-    const format = file.type.split("/")[1] || "png";
-    const reader = new FileReader();
-    reader.onload = () => {
-      const dataUrl = reader.result as string;
-      const base64 = dataUrl.split(",")[1];
-      usePipelineStore.getState().setOriginalImage(base64, format);
-
+    loadImageFile(file).then(() => {
       const label = block.getField("filename_label");
       if (label) label.setValue(file.name);
-    };
-    reader.readAsDataURL(file);
+    });
 
-    // Reset so re-selecting the same file triggers change
     fileInput.value = "";
   });
 
-  // Wire the field_image click to open the file picker
   const uploadField = block.getField("upload_button");
   if (uploadField) {
     (uploadField as Blockly.FieldImage).setOnClickHandler(() => {
@@ -39,7 +30,6 @@ function initReadImageBlock(block: Blockly.Block) {
     });
   }
 
-  // Register a reset callback when the image is cleared
   usePipelineStore.getState().registerImageReset(() => {
     const label = block.getField("filename_label");
     if (label) label.setValue("No image");

--- a/imagelab-frontend/src/components/Layout.tsx
+++ b/imagelab-frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useBlocklyWorkspace } from "../hooks/useBlocklyWorkspace";
 import { usePipelineStore } from "../store/pipelineStore";
+import { useImageDropAndPaste } from "../hooks/useImageUpload";
 import { useDarkMode } from "../hooks/useDarkMode";
 import Navbar from "./Navbar";
 import Toolbar from "./Toolbar";
@@ -8,12 +9,15 @@ import Sidebar from "./Sidebar/Sidebar";
 import PreviewPane from "./Preview/PreviewPane";
 import InfoPane from "./InfoPane";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { Upload } from "lucide-react";
 
 export default function Layout() {
   const [isDark, toggleDark] = useDarkMode();
   const { containerRef, workspace } = useBlocklyWorkspace({ isDark });
   const { reset } = usePipelineStore();
   const [resetKey, setResetKey] = useState(0);
+  const workspaceAreaRef = useRef<HTMLDivElement>(null);
+  const { isDragging } = useImageDropAndPaste(workspaceAreaRef, workspace);
 
   const handleEditorReset = () => {
     setResetKey((prev) => prev + 1);
@@ -28,9 +32,17 @@ export default function Layout() {
         <Sidebar workspace={workspace} />
         <ErrorBoundary key={resetKey} onReset={handleEditorReset}>
           <div className="flex-1 flex min-w-0">
-            <div className="flex-1 flex flex-col min-w-0">
+            <div className="flex-1 flex flex-col min-w-0 relative" ref={workspaceAreaRef}>
               <div ref={containerRef} className="flex-1" />
               <InfoPane />
+              {isDragging && (
+                <div className="drop-overlay">
+                  <div className="drop-overlay__inner">
+                    <Upload size={32} className="text-indigo-400 mb-2" />
+                    <p className="text-sm font-medium text-gray-700">Drop image to load</p>
+                  </div>
+                </div>
+              )}
             </div>
             <PreviewPane />
           </div>

--- a/imagelab-frontend/src/hooks/useImageUpload.ts
+++ b/imagelab-frontend/src/hooks/useImageUpload.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Blockly from "blockly";
+import { usePipelineStore } from "../store/pipelineStore";
+
+function normaliseFormat(mimeType: string): string {
+  const sub = mimeType.split("/")[1] ?? "png";
+  if (sub === "jpg") return "jpeg";
+  if (sub === "tif") return "tiff";
+  return sub;
+}
+
+export function loadImageFile(file: File, onLoaded?: (filename: string) => void): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!file.type.startsWith("image/")) {
+      resolve();
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      const base64 = dataUrl.split(",")[1];
+      usePipelineStore.getState().setOriginalImage(base64, normaliseFormat(file.type));
+      onLoaded?.(file.name);
+      resolve();
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function updateReadImageLabel(workspace: Blockly.WorkspaceSvg, filename: string) {
+  const blocks = workspace.getBlocksByType("basic_readimage", false);
+  if (blocks.length > 0) {
+    blocks[0].getField("filename_label")?.setValue(filename);
+  }
+}
+
+export function useImageDropAndPaste(
+  dropTargetRef: React.RefObject<HTMLElement | null>,
+  workspace: Blockly.WorkspaceSvg | null,
+) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounter = useRef(0);
+
+  const handleFile = useCallback(
+    (file: File) => {
+      loadImageFile(file, (filename) => {
+        if (workspace) updateReadImageLabel(workspace, filename);
+      });
+    },
+    [workspace],
+  );
+
+  useEffect(() => {
+    const el = dropTargetRef.current;
+    if (!el) return;
+
+    const onDragEnter = (e: DragEvent) => {
+      e.preventDefault();
+      dragCounter.current += 1;
+      if (dragCounter.current === 1) setIsDragging(true);
+    };
+    const onDragOver = (e: DragEvent) => {
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    };
+    const onDragLeave = (e: DragEvent) => {
+      e.preventDefault();
+      dragCounter.current -= 1;
+      if (dragCounter.current === 0) setIsDragging(false);
+    };
+    const onDrop = (e: DragEvent) => {
+      e.preventDefault();
+      dragCounter.current = 0;
+      setIsDragging(false);
+      const file = e.dataTransfer?.files[0];
+      if (file) handleFile(file);
+    };
+
+    el.addEventListener("dragenter", onDragEnter);
+    el.addEventListener("dragover", onDragOver);
+    el.addEventListener("dragleave", onDragLeave);
+    el.addEventListener("drop", onDrop);
+    return () => {
+      el.removeEventListener("dragenter", onDragEnter);
+      el.removeEventListener("dragover", onDragOver);
+      el.removeEventListener("dragleave", onDragLeave);
+      el.removeEventListener("drop", onDrop);
+    };
+  }, [dropTargetRef, handleFile]);
+
+  useEffect(() => {
+    const onPaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (const item of items) {
+        if (item.kind === "file" && item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          if (file) {
+            handleFile(file);
+            break;
+          }
+        }
+      }
+    };
+    document.addEventListener("paste", onPaste);
+    return () => document.removeEventListener("paste", onPaste);
+  }, [handleFile]);
+
+  return { isDragging };
+}

--- a/imagelab-frontend/src/index.css
+++ b/imagelab-frontend/src/index.css
@@ -49,3 +49,23 @@
 .blocklyScrollbarVertical {
   display: none !important;
 }
+
+.drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  background: rgba(238, 242, 255, 0.85);
+  border: 2px dashed #818cf8;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.drop-overlay__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}


### PR DESCRIPTION
## Description
Adds drag-and-drop and clipboard paste as image upload paths, alongside the existing file picker on the Read Image block.

A new `useImageDropAndPaste` hook registers `dragenter`, `dragover`, `dragleave`, and `drop` listeners on the workspace area, and a `paste` listener on `document`. Both paths call a shared `loadImageFile` utility which handles base64 encoding and format normalisation. On successful load the Read Image block's filename label is updated to match the dropped or pasted file, consistent with the file picker behaviour. A drop overlay renders over the workspace while a drag is in progress.

Fixes #229 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

Manually verified: drag from desktop loads image and updates block label, `Ctrl+V` paste from clipboard loads image and updates block label, file picker continues to work unchanged, drop overlay appears and disappears correctly, no operation when dragging non-image files.

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally