### PR TITLE
feat: add debug mode to pipeline executor with per-step frames

### DIFF
--- a/imagelab-backend/app/models/pipeline.py
+++ b/imagelab-backend/app/models/pipeline.py
@@ -10,6 +10,7 @@ class PipelineRequest(BaseModel):
     image: str
     image_format: str = "png"
     pipeline: list[PipelineStep]
+    debug: bool = False
 
 
 class StepTiming(BaseModel):
@@ -30,3 +31,4 @@ class PipelineResponse(BaseModel):
     error: str | None = None
     step: int | None = None
     timings: PipelineTimings | None = None
+    debug_frames: list[str] | None = None

--- a/imagelab-backend/app/services/pipeline_executor.py
+++ b/imagelab-backend/app/services/pipeline_executor.py
@@ -7,10 +7,6 @@ from app.utils.image import decode_base64_image, encode_image_base64
 NOOP_TYPES = {"basic_readimage", "basic_writeimage", "border_for_all", "border_each_side"}
 
 
-# Thread-safety: this function is safe to call concurrently from FastAPI's
-# threadpool. All processing state (image array, operator instances, encoded
-# output) is local to each invocation. The module-level NOOP_TYPES set and
-# OPERATOR_REGISTRY dict are read-only after import and never mutated.
 def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
     """
     Execute the image-processing pipeline described by *request*.
@@ -19,9 +15,15 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
     populated with every step that completed before the function returned,
     even when the response indicates failure.  This allows callers to
     inspect partial execution progress on error.
+
+    When ``request.debug`` is True, a ``debug_frames`` list is included in
+    the response containing one base64-encoded image per non-NOOP step,
+    in execution order.  This allows callers to step through the effect of
+    each operator on the image.
     """
     t_start_total = time.perf_counter()
     step_timings: list[StepTiming] = []
+    debug_frames: list[str] = []
 
     try:
         image = decode_base64_image(request.image)
@@ -56,6 +58,8 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             step_timings.append(
                 StepTiming(step=i + 1, operator_type=step.type, duration_ms=(t_step_end - t_step_start) * 1000)
             )
+            if request.debug:
+                debug_frames.append(encode_image_base64(image, request.image_format))
         except Exception as e:
             t_fail = time.perf_counter()
             return PipelineResponse(
@@ -69,10 +73,9 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
         encoded = encode_image_base64(image, request.image_format)
     except Exception as e:
         t_fail = time.perf_counter()
-        error_msg = f"Failed to encode result: {type(e).__name__}: {e}"
         return PipelineResponse(
             success=False,
-            error=error_msg,
+            error=f"Failed to encode result: {type(e).__name__}: {e}",
             step=len(request.pipeline),
             timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
         )
@@ -84,4 +87,5 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
         image=encoded,
         image_format=request.image_format,
         timings=PipelineTimings(total_ms=(t_end_total - t_start_total) * 1000, steps=step_timings),
+        debug_frames=debug_frames if request.debug else None,
     )

--- a/imagelab-backend/tests/test_pipeline_debug.py
+++ b/imagelab-backend/tests/test_pipeline_debug.py
@@ -1,0 +1,97 @@
+"""Tests for the debug mode pipeline execution."""
+
+EXECUTE_URL = "/api/pipeline/execute"
+
+GRAY_STEP = {"type": "imageconvertions_grayimage", "params": {}}
+BLUR_STEP = {"type": "blurring_applygaussianblur", "params": {"widthSize": 3, "heightSize": 3}}
+NOOP_STEP = {"type": "basic_readimage", "params": {}}
+
+
+def post(client, png_b64, pipeline, debug=False):
+    return client.post(
+        EXECUTE_URL,
+        json={"image": png_b64, "image_format": "png", "pipeline": pipeline, "debug": debug},
+    )
+
+
+def test_debug_false_returns_no_frames(client, png_b64):
+    r = post(client, png_b64, [GRAY_STEP], debug=False)
+    assert r.json()["debug_frames"] is None
+
+
+def test_debug_omitted_returns_no_frames(client, png_b64):
+    r = client.post(
+        EXECUTE_URL,
+        json={"image": png_b64, "image_format": "png", "pipeline": [GRAY_STEP]},
+    )
+    assert r.json()["debug_frames"] is None
+
+
+def test_debug_true_single_step_returns_one_frame(client, png_b64):
+    r = post(client, png_b64, [GRAY_STEP], debug=True)
+    data = r.json()
+    assert data["success"] is True
+    assert data["debug_frames"] is not None
+    assert len(data["debug_frames"]) == 1
+
+
+def test_debug_frame_count_matches_non_noop_steps(client, png_b64):
+    r = post(client, png_b64, [GRAY_STEP, BLUR_STEP], debug=True)
+    data = r.json()
+    assert data["success"] is True
+    assert len(data["debug_frames"]) == 2
+
+
+def test_noop_steps_excluded_from_debug_frames(client, png_b64):
+    r = post(client, png_b64, [NOOP_STEP, GRAY_STEP], debug=True)
+    data = r.json()
+    assert data["success"] is True
+    # NOOP_STEP is skipped — only GRAY_STEP produces a frame
+    assert len(data["debug_frames"]) == 1
+
+
+def test_debug_frames_are_valid_base64_strings(client, png_b64):
+    import base64
+
+    r = post(client, png_b64, [GRAY_STEP], debug=True)
+    frame = r.json()["debug_frames"][0]
+    # Should not raise
+    decoded = base64.b64decode(frame)
+    assert len(decoded) > 0
+
+
+def test_debug_frames_differ_between_steps(client, png_b64):
+    import base64
+    import cv2
+    import numpy as np
+
+    # Non-uniform image so gaussian blur produces a visibly different result
+    rng = np.random.default_rng(0)
+    img = rng.integers(0, 256, (50, 50, 3), dtype=np.uint8)
+    _, buf = cv2.imencode(".png", img)
+    noisy_b64 = base64.b64encode(buf.tobytes()).decode()
+
+    r = post(client, noisy_b64, [GRAY_STEP, BLUR_STEP], debug=True)
+    data = r.json()
+    assert data["debug_frames"][0] != data["debug_frames"][1]
+
+
+def test_last_debug_frame_matches_final_image(client, png_b64):
+    r = post(client, png_b64, [GRAY_STEP, BLUR_STEP], debug=True)
+    data = r.json()
+    assert data["debug_frames"][-1] == data["image"]
+
+
+def test_debug_on_empty_pipeline_returns_empty_frames(client, png_b64):
+    r = post(client, png_b64, [], debug=True)
+    data = r.json()
+    assert data["success"] is True
+    assert data["debug_frames"] == []
+
+
+def test_debug_on_failure_returns_no_frames(client, png_b64):
+    bad_step = {"type": "not_a_real_operator", "params": {}}
+    r = post(client, png_b64, [bad_step], debug=True)
+    data = r.json()
+    assert data["success"] is False
+    assert data["debug_frames"] is None

--- a/imagelab-backend/tests/test_pipeline_debug.py
+++ b/imagelab-backend/tests/test_pipeline_debug.py
@@ -62,6 +62,7 @@ def test_debug_frames_are_valid_base64_strings(client, png_b64):
 
 def test_debug_frames_differ_between_steps(client, png_b64):
     import base64
+
     import cv2
     import numpy as np
 

--- a/imagelab-frontend/src/components/Preview/PreviewPane.tsx
+++ b/imagelab-frontend/src/components/Preview/PreviewPane.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
-import { ZoomIn, ZoomOut, Image, ImageDown, Trash2, Timer } from "lucide-react";
+import {
+  ZoomIn,
+  ZoomOut,
+  Image,
+  ImageDown,
+  Trash2,
+  Timer,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { usePipelineStore } from "../../store/pipelineStore";
 import ImageDisplay from "./ImageDisplay";
 
@@ -34,15 +43,25 @@ function ZoomControls({
   );
 }
 
-// Operator types follow 'category_operationName' convention; strip the category prefix for display.
 function getStepLabel(operatorType: string): string {
   const underscoreIndex = operatorType.indexOf("_");
   return underscoreIndex !== -1 ? operatorType.slice(underscoreIndex + 1) : operatorType;
 }
 
 export default function PreviewPane() {
-  const { originalImage, imageFormat, processedImage, error, errorStep, clearImage, timings } =
-    usePipelineStore();
+  const {
+    originalImage,
+    imageFormat,
+    processedImage,
+    error,
+    errorStep,
+    clearImage,
+    timings,
+    debugFrames,
+    debugStep,
+    setDebugStep,
+  } = usePipelineStore();
+
   const [originalZoom, setOriginalZoom] = useState<number | null>(null);
   const [processedZoom, setProcessedZoom] = useState<number | null>(null);
 
@@ -50,6 +69,15 @@ export default function PreviewPane() {
     setter((prev) => Math.min((prev ?? 300) + 100, 2500));
   const zoomOut = (setter: React.Dispatch<React.SetStateAction<number | null>>) => () =>
     setter((prev) => Math.max((prev ?? 300) - 100, 100));
+
+  const totalFrames = debugFrames?.length ?? 0;
+  const currentFrame = debugFrames?.[debugStep] ?? null;
+  const currentStepMeta = timings?.steps[debugStep] ?? null;
+
+  const handlePrev = () => setDebugStep(Math.max(0, debugStep - 1));
+  const handleNext = () => setDebugStep(Math.min(totalFrames - 1, debugStep + 1));
+
+  const activeImage = debugFrames ? currentFrame : processedImage;
 
   return (
     <div className="w-80 h-full bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col flex-shrink-0">
@@ -86,15 +114,15 @@ export default function PreviewPane() {
         />
       </div>
 
-      {/* Processed image — bottom half */}
+      {/* Processed / debug panel — bottom half */}
       <div className="flex-1 flex flex-col min-h-0">
         <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-center gap-1.5">
             <ImageDown size={14} className="text-gray-400" />
             <h2 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-              Processed
+              {debugFrames ? "Debug" : "Processed"}
             </h2>
-            {timings && !error && (
+            {timings && !error && !debugFrames && (
               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 text-[11px] font-medium text-green-700 dark:text-green-400 ml-1 mt-[-1px]">
                 <Timer size={10} className="text-green-600 dark:text-green-400" />
                 {timings.total_ms.toFixed(1)} ms
@@ -108,15 +136,82 @@ export default function PreviewPane() {
             )}
           </div>
         </div>
+
         <div className="flex-1 flex items-center justify-center p-3 bg-gray-50 dark:bg-gray-900 overflow-auto">
-          {processedImage ? (
-            <ImageDisplay image={processedImage} format={imageFormat} zoomWidth={processedZoom} />
+          {activeImage ? (
+            <ImageDisplay image={activeImage} format={imageFormat} zoomWidth={processedZoom} />
           ) : (
             <p className="text-sm text-gray-400 dark:text-gray-500">
               {originalImage ? "Run the pipeline to see results" : "No image loaded"}
             </p>
           )}
         </div>
+
+        {/* Step scrubber — only shown in debug mode with frames */}
+        {debugFrames && totalFrames > 0 && (
+          <div className="px-3 py-2 bg-indigo-50 border-t border-indigo-100">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-[11px] font-semibold text-indigo-700 uppercase tracking-wide">
+                Step {debugStep + 1} of {totalFrames}
+              </span>
+              {currentStepMeta && (
+                <span
+                  className="text-[11px] text-indigo-500 truncate max-w-[120px]"
+                  title={currentStepMeta.operator_type}
+                >
+                  {getStepLabel(currentStepMeta.operator_type)}
+                </span>
+              )}
+            </div>
+
+            {/* Progress bar */}
+            <div className="w-full h-1 bg-indigo-100 rounded-full mb-2">
+              <div
+                className="h-full bg-indigo-400 rounded-full transition-all duration-150"
+                style={{ width: `${((debugStep + 1) / totalFrames) * 100}%` }}
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handlePrev}
+                disabled={debugStep === 0}
+                className="flex items-center justify-center p-1 rounded border border-indigo-200 bg-white text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                title="Previous step"
+              >
+                <ChevronLeft size={14} />
+              </button>
+
+              {/* Step dots */}
+              <div className="flex items-center gap-1 flex-1 justify-center flex-wrap">
+                {Array.from({ length: totalFrames }, (_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setDebugStep(i)}
+                    className={`w-2 h-2 rounded-full transition-colors ${
+                      i === debugStep ? "bg-indigo-500" : "bg-indigo-200 hover:bg-indigo-300"
+                    }`}
+                    title={
+                      timings?.steps[i]
+                        ? getStepLabel(timings.steps[i].operator_type)
+                        : `Step ${i + 1}`
+                    }
+                  />
+                ))}
+              </div>
+
+              <button
+                onClick={handleNext}
+                disabled={debugStep === totalFrames - 1}
+                className="flex items-center justify-center p-1 rounded border border-indigo-200 bg-white text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                title="Next step"
+              >
+                <ChevronRight size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+
         {error && (
           <div className="px-3 py-2 bg-red-50 dark:bg-red-900/30 border-t border-red-200 dark:border-red-800">
             <p className="text-xs text-red-600 dark:text-red-400 font-semibold mb-0.5">
@@ -125,7 +220,8 @@ export default function PreviewPane() {
             <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
           </div>
         )}
-        {timings && timings.steps.length > 0 && (
+
+        {timings && timings.steps.length > 0 && !debugFrames && (
           <div className="px-3 py-2 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
             <details className="group">
               <summary className="text-[10px] uppercase font-semibold text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 cursor-pointer select-none">
@@ -165,8 +261,9 @@ export default function PreviewPane() {
             </details>
           </div>
         )}
+
         <ZoomControls
-          disabled={!processedImage}
+          disabled={!activeImage}
           onZoomIn={zoomIn(setProcessedZoom)}
           onZoomOut={zoomOut(setProcessedZoom)}
         />

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect } from "react";
 import * as Blockly from "blockly";
-import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Bug, Keyboard } from "lucide-react";
+import {
+  FilePlus,
+  Download,
+  Undo2,
+  Redo2,
+  Play,
+  Loader2,
+  Share2,
+  Bug,
+  Keyboard,
+} from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import * as Blockly from "blockly";
-import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Keyboard } from "lucide-react";
+import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Bug, Keyboard } from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
@@ -32,6 +32,9 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     uniqueBlockTypes,
     categoryCounts,
     complexity,
+    isDebugMode,
+    setDebugMode,
+    setDebugFrames,
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
@@ -68,18 +71,21 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     setExecuting(true);
     setError(null);
     setTiming(null);
+    setDebugFrames(null);
 
     try {
       const response = await executePipeline({
         image: originalImage,
         image_format: imageFormat,
         pipeline,
+        debug: isDebugMode,
       });
 
       setTiming(response.timings ?? null);
 
       if (response.success && response.image) {
         setProcessedImage(response.image);
+        setDebugFrames(response.debug_frames ?? null);
       } else {
         setError(response.error || "Pipeline execution failed", response.step);
       }
@@ -156,6 +162,20 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           title="Share Pipeline"
         >
           <Share2 size={18} />
+        </button>
+
+        <button
+          onClick={() => setDebugMode(!isDebugMode)}
+          className={`p-1.5 rounded transition-colors ${
+            isDebugMode
+              ? "bg-indigo-100 text-indigo-600 hover:bg-indigo-200"
+              : "hover:bg-gray-100 text-gray-600"
+          }`}
+          title={
+            isDebugMode ? "Debug mode on — click to disable" : "Enable step-by-step debug mode"
+          }
+        >
+          <Bug size={18} />
         </button>
 
         <button

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -19,6 +19,12 @@ interface PipelineState {
   uniqueBlockTypes: number;
   categoryCounts: Record<string, number>;
   complexity: "Low" | "Medium" | "High";
+
+  // Debug mode
+  isDebugMode: boolean;
+  debugFrames: string[] | null;
+  debugStep: number;
+
   setOriginalImage: (image: string, format: string) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
@@ -30,6 +36,10 @@ interface PipelineState {
   clearImage: () => void;
   _imageResetFn: (() => void) | null;
   registerImageReset: (fn: () => void) => void;
+
+  setDebugMode: (on: boolean) => void;
+  setDebugFrames: (frames: string[] | null) => void;
+  setDebugStep: (step: number) => void;
 }
 
 function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" | "High" {
@@ -53,6 +63,10 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   uniqueBlockTypes: 0,
   categoryCounts: {},
   complexity: "Low",
+  isDebugMode: false,
+  debugFrames: null,
+  debugStep: 0,
+
   setOriginalImage: (image, format) =>
     set({
       originalImage: image,
@@ -60,6 +74,8 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       processedImage: null,
       error: null,
       timings: null,
+      debugFrames: null,
+      debugStep: 0,
     }),
   setProcessedImage: (image) => set({ processedImage: image, error: null, errorStep: null }),
   setExecuting: (executing) => set({ isExecuting: executing }),
@@ -78,27 +94,29 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       error: null,
       errorStep: null,
       timings: null,
+      debugFrames: null,
+      debugStep: 0,
     });
   },
+  setDebugMode: (on) => set({ isDebugMode: on, debugFrames: null, debugStep: 0 }),
+  setDebugFrames: (frames) => set({ debugFrames: frames, debugStep: 0 }),
+  setDebugStep: (step) => set({ debugStep: step }),
+
   updateBlockStats: (workspace) => {
     const blocks = workspace.getAllBlocks(false);
-
     const typeToCategory: Record<string, string> = {};
     categories.forEach((cat) => {
       cat.blocks.forEach((b) => {
         typeToCategory[b.type] = cat.name;
       });
     });
-
     const uniqueTypes = new Set<string>();
     const counts: Record<string, number> = {};
-
     blocks.forEach((block) => {
       uniqueTypes.add(block.type);
       const cat = typeToCategory[block.type] || "Unknown";
       counts[cat] = (counts[cat] || 0) + 1;
     });
-
     set({
       blockCount: blocks.length,
       uniqueBlockTypes: uniqueTypes.size,
@@ -106,6 +124,7 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       complexity: calculateComplexity(blocks.length, uniqueTypes.size),
     });
   },
+
   reset: () =>
     set({
       originalImage: null,
@@ -121,5 +140,8 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       categoryCounts: {},
       complexity: "Low",
       timings: null,
+      isDebugMode: false,
+      debugFrames: null,
+      debugStep: 0,
     }),
 }));

--- a/imagelab-frontend/src/types/pipeline.ts
+++ b/imagelab-frontend/src/types/pipeline.ts
@@ -7,6 +7,7 @@ export interface PipelineRequest {
   image: string;
   image_format: string;
   pipeline: PipelineStep[];
+  debug?: boolean;
 }
 
 export interface StepTiming {
@@ -27,4 +28,5 @@ export interface PipelineResponse {
   error?: string;
   step?: number;
   timings?: PipelineTimings;
+  debug_frames?: string[];
 }


### PR DESCRIPTION
## Description
When a pipeline produces an unexpected result, the only way to diagnose it is to remove blocks one by one and re-run. This PR adds a debug mode that lets users step through each operator's output interactively.A Bug icon toggle in the toolbar enables debug mode. When active, running the pipeline captures the image after every operator on the backend and returns the frames alongside the final result. In the preview pane, the processed image panel is replaced by a step scrubber — prev/next buttons and clickable dots let you move through each frame, with the operator name and a progress bar shown above.Turning debug mode off restores the normal preview behaviour. No existing functionality is affected when debug is disabled.

Fixes #232 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Added a new test`test_pipeline_debug.py`

Manually verified: toggle activates and deactivates correctly, scrubber prev/next and dot navigation work, operator name updates per step, debug state clears when a new image is loaded.

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally