### PR TITLE
fix(filtering): Fix GaborFilter lambda parameter mismatch between frontend and backend

### DIFF
--- a/imagelab-backend/app/operators/filtering/gabor_filter.py
+++ b/imagelab-backend/app/operators/filtering/gabor_filter.py
@@ -12,7 +12,7 @@ class GaborFilter(BaseOperator):
         kernel_size = int(self.params.get("kernelSize", 21))
         sigma = max(0.1, float(self.params.get("sigma", 5.0)))
         theta = float(self.params.get("theta", 0.0))
-        lambda_ = max(1.0, float(self.params.get("lambda", 10.0)))
+        lambda_ = max(1.0, float(self.params.get("lambda_", 10.0)))
         gamma = max(0.01, float(self.params.get("gamma", 0.5)))
 
         kernel_size = max(1, min(kernel_size, MAX_KERNEL_SIZE))


### PR DESCRIPTION
## Description

Fixes a parameter key mismatch in the GaborFilter operator.

The frontend Blockly block defines the wavelength parameter as `lambda_`, and the
pipeline extraction logic sends it with the same key. However, the backend
implementation in `gabor_filter.py` was reading the parameter using the key
`lambda`, causing the lookup to always miss and fall back to the default value
(10.0).

As a result, user-specified lambda values in the UI were silently ignored during
pipeline execution.

This PR updates the backend parameter lookup to use `lambda_`, aligning it with
the key sent by the frontend.

Fixes #238
___
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
___
## How Has This Been Tested?

- Verified the Gabor filter pipeline using multiple lambda values.
- Confirmed that changing the lambda parameter in the UI now produces different outputs.
- Ran the existing test suite locally to ensure no regressions.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing
___
## Screenshots (if applicable)
N/A
___
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
