### PR TITLE
fix(drawing): clamp negative radius to 0 in DrawCircle

### DIFF
--- a/imagelab-backend/app/operators/drawing/draw_circle.py
+++ b/imagelab-backend/app/operators/drawing/draw_circle.py
@@ -9,7 +9,7 @@ class DrawCircle(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         result = image.copy()
         thickness = int(self.params.get("thickness", 2))
-        radius = int(self.params.get("radius", 5))
+        radius = max(0, int(self.params.get("radius", 5)))
         color = hex_to_bgr(self.params.get("rgbcolors_input", "#2828cc"))
         cx = int(self.params.get("center_point_x", 0))
         cy = int(self.params.get("center_point_y", 0))

--- a/imagelab-backend/app/operators/drawing/draw_circle.py
+++ b/imagelab-backend/app/operators/drawing/draw_circle.py
@@ -1,11 +1,8 @@
 ﻿import cv2
 import numpy as np
-                          ← blank line here
-from app.operators.base import BaseOperator
+                          app.operators.base import BaseOperator
 from app.utils.color import hex_to_bgr
-                          ← blank line here
-                          ← blank line here
-class DrawCircle(BaseOperator):
+                         class DrawCircle(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         result = image.copy()
         thickness = int(self.params.get("thickness", 2))
@@ -15,4 +12,4 @@ class DrawCircle(BaseOperator):
         cy = int(self.params.get("center_point_y", 0))
         cv2.circle(result, (cx, cy), radius, color, thickness)
         return result
-                          ← blank line here (at end of file)
+                          

--- a/imagelab-backend/app/operators/drawing/draw_circle.py
+++ b/imagelab-backend/app/operators/drawing/draw_circle.py
@@ -1,8 +1,11 @@
-﻿import cv2
+import cv2
 import numpy as np
-                          app.operators.base import BaseOperator
+
+from app.operators.base import BaseOperator
 from app.utils.color import hex_to_bgr
-                         class DrawCircle(BaseOperator):
+
+
+class DrawCircle(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         result = image.copy()
         thickness = int(self.params.get("thickness", 2))
@@ -12,4 +15,4 @@ from app.utils.color import hex_to_bgr
         cy = int(self.params.get("center_point_y", 0))
         cv2.circle(result, (cx, cy), radius, color, thickness)
         return result
-                          
+

--- a/imagelab-backend/app/operators/drawing/draw_circle.py
+++ b/imagelab-backend/app/operators/drawing/draw_circle.py
@@ -1,10 +1,10 @@
-import cv2
+﻿import cv2
 import numpy as np
-
+                          ← blank line here
 from app.operators.base import BaseOperator
 from app.utils.color import hex_to_bgr
-
-
+                          ← blank line here
+                          ← blank line here
 class DrawCircle(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         result = image.copy()
@@ -15,3 +15,4 @@ class DrawCircle(BaseOperator):
         cy = int(self.params.get("center_point_y", 0))
         cv2.circle(result, (cx, cy), radius, color, thickness)
         return result
+                          ← blank line here (at end of file)

--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -7,13 +7,10 @@ HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
     """
     Convert a 6-digit CSS hex color string to a BGR tuple for OpenCV.
-
     Args:
         hex_color: A 6-digit hex color string, with or without a leading '#'.
-
     Returns:
         A (blue, green, red) tuple of integers.
-
     Raises:
         TypeError: If hex_color is not a string.
         ValueError: If hex_color is not a valid 6-digit hex color string.
@@ -22,16 +19,14 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         raise TypeError(
             f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
         )
-
     original = hex_color
     normalized = hex_color.removeprefix("#")
-
     if not HEX_COLOR_RE.fullmatch(normalized):
         raise ValueError(
             f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
         )
-
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)
     b = int(normalized[4:6], 16)
     return (b, g, r)
+


### PR DESCRIPTION

The `DrawCircle` operator did not validate the `radius` parameter before
passing it to `cv2.circle()`. Passing a negative value (e.g. `radius=-5`)
caused OpenCV to throw an error and crash the entire pipeline with no
useful error message.


Clamped `radius` to a minimum of `0` using `max(0, ...)` — so instead
of crashing, the operator silently draws a zero-radius circle (a point):

python
radius = int(self.params.get("radius", 5))


python
radius = max(0, int(self.params.get("radius", 5)))



This follows the same defensive validation pattern already applied in
`ApplyBorders` (#220) and `ScaleImage` (#120). `DrawCircle` should
be consistent with those operators. 🔵