### PR TITLE
feat: implement Workplace saving feature using LocalStorage

### DIFF
--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -80,9 +80,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import * as Blockly from "blockly";
-import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2 } from "lucide-react";
+import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Layout } from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import SharePipelineModal from "./SharePipelineModal";
+import WorkspaceModal from "./WorkspaceModal";
 
 interface ToolbarProps {
   workspace: Blockly.WorkspaceSvg | null;
@@ -34,6 +35,7 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showWorkspaceModal, setShowWorkspaceModal] = useState(false);
 
   const handleNew = () => {
     if (!window.confirm("This will clear all blocks and the uploaded image. Continue?")) {
@@ -137,6 +139,16 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           <Share2 size={18} />
         </button>
 
+        <button
+          onClick={() => setShowWorkspaceModal(true)}
+          disabled={!workspace}
+          className={`${iconBtn} flex items-center gap-1.5 px-3 hover:bg-indigo-50 hover:text-indigo-600`}
+          title="Workspaces"
+        >
+          <Layout size={18} />
+          <span className="text-sm font-medium">Workspace</span>
+        </button>
+
         <div className={separator} />
 
         <button
@@ -204,6 +216,9 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
       {showShareModal && (
         <SharePipelineModal workspace={workspace} onClose={() => setShowShareModal(false)} />
+      )}
+      {showWorkspaceModal && (
+        <WorkspaceModal workspace={workspace} onClose={() => setShowWorkspaceModal(false)} />
       )}
     </>
   );

--- a/imagelab-frontend/src/components/WorkspaceModal.tsx
+++ b/imagelab-frontend/src/components/WorkspaceModal.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from "react";
+import * as Blockly from "blockly";
+import { X, Save, Trash2, FolderOpen, Layout } from "lucide-react";
+import { useWorkspaceStore } from "../store/workspaceStore";
+import { usePipelineStore } from "../store/pipelineStore";
+
+interface WorkspaceModalProps {
+  workspace: Blockly.WorkspaceSvg | null;
+  onClose: () => void;
+}
+
+export default function WorkspaceModal({ workspace, onClose }: WorkspaceModalProps) {
+  const { workspaces, loadWorkspaces, saveWorkspace, deleteWorkspace } = useWorkspaceStore();
+  const { reset, clearImage } = usePipelineStore();
+  const [saveName, setSaveName] = useState("");
+
+  useEffect(() => {
+    loadWorkspaces();
+  }, [loadWorkspaces]);
+
+  const handleSave = () => {
+    if (!saveName.trim() || !workspace) return;
+    const data = Blockly.serialization.workspaces.save(workspace);
+    saveWorkspace(saveName.trim(), data);
+    setSaveName("");
+  };
+
+  const handleLoad = (templateData: Record<string, unknown>) => {
+    if (!workspace) return;
+
+    if (workspace.getAllBlocks(false).length > 0) {
+      if (
+        !window.confirm(
+          "Loading this workspace will clear your current blocks and uploaded image. Continue?",
+        )
+      ) {
+        return;
+      }
+    }
+
+    clearImage();
+    reset();
+    workspace.clear();
+    Blockly.serialization.workspaces.load(templateData, workspace);
+    onClose();
+  };
+
+  const handleDelete = (id: string) => {
+    if (window.confirm("Are you sure you want to delete this workspace?")) {
+      deleteWorkspace(id);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md flex flex-col max-h-[85vh]">
+        <div className="flex items-center justify-between p-4 border-b border-gray-100">
+          <div className="flex items-center gap-2 text-gray-800">
+            <Layout className="w-5 h-5 text-indigo-600" />
+            <h2 className="font-semibold text-lg">Workspaces</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-500 transition-colors"
+            title="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="p-4 border-b border-gray-100 bg-gray-50 flex flex-col gap-3">
+          <label className="text-sm font-medium text-gray-700">Save Current Pipeline</label>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={saveName}
+              onChange={(e) => setSaveName(e.target.value)}
+              placeholder="e.g. Edge Detection Setup"
+              className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500"
+              onKeyDown={(e) => e.key === "Enter" && handleSave()}
+            />
+            <button
+              onClick={handleSave}
+              disabled={!saveName.trim() || !workspace}
+              className="flex items-center gap-1.5 px-4 py-2 bg-indigo-600 text-white rounded-lg text-sm font-medium hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Save size={16} />
+              Save
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-2">
+          {workspaces.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              <FolderOpen className="w-10 h-10 mx-auto text-gray-300 mb-2" />
+              <p>No saved workspaces yet.</p>
+              <p className="text-xs mt-1">Save your current pipeline above.</p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {workspaces.map((ws) => (
+                <div
+                  key={ws.id}
+                  className="group flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 border border-transparent hover:border-gray-200 transition-all"
+                >
+                  <div className="flex flex-col min-w-0 pr-4">
+                    <span className="font-medium text-sm text-gray-800 truncate">{ws.name}</span>
+                    <span className="text-xs text-gray-500">
+                      {new Date(ws.createdAt).toLocaleDateString()}{" "}
+                      {new Date(ws.createdAt).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => handleLoad(ws.data)}
+                      className="px-3 py-1.5 bg-white border border-gray-300 flex items-center gap-1.5 text-gray-700 rounded-md text-xs font-medium hover:bg-gray-50 hover:text-indigo-600 hover:border-indigo-200 transition-colors"
+                    >
+                      Load
+                    </button>
+                    <button
+                      onClick={() => handleDelete(ws.id)}
+                      className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                      title="Delete Workspace"
+                    >
+                      <Trash2 size={16} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/store/workspaceStore.ts
+++ b/imagelab-frontend/src/store/workspaceStore.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+
+export interface SavedWorkspace {
+  id: string;
+  name: string;
+  data: Record<string, unknown>;
+  createdAt: number;
+}
+
+interface WorkspaceState {
+  workspaces: SavedWorkspace[];
+  loadWorkspaces: () => void;
+  saveWorkspace: (name: string, data: Record<string, unknown>) => void;
+  deleteWorkspace: (id: string) => void;
+}
+
+const STORAGE_KEY = "imagelab_workspaces";
+
+export const useWorkspaceStore = create<WorkspaceState>((set) => ({
+  workspaces: [],
+  loadWorkspaces: () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        set({ workspaces: JSON.parse(stored) });
+      }
+    } catch (e) {
+      console.error("Failed to load workspaces", e);
+    }
+  },
+  saveWorkspace: (name, data) => {
+    set((state) => {
+      const newWorkspace: SavedWorkspace = {
+        id: crypto.randomUUID(),
+        name,
+        data,
+        createdAt: Date.now(),
+      };
+      const updated = [newWorkspace, ...state.workspaces];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return { workspaces: updated };
+    });
+  },
+  deleteWorkspace: (id) => {
+    set((state) => {
+      const updated = state.workspaces.filter((w) => w.id !== id);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      return { workspaces: updated };
+    });
+  },
+}));


### PR DESCRIPTION
**## Description**

This Pull Request introduces the **Workspace** feature, allowing users to save, manage, and load their Blockly pipeline configurations directly within their browser utilizing LocalStorage. This resolves the friction point where users previously lost their complex node configuration upon clearing the canvas or refreshing the page.

Closes #212 

**## Changes Proposed**
- **New State Management:** Created a dedicated Zustand store (`workspaceStore.ts`) to handle serializing, storing, retrieving, and deleting Blockly JSON payloads locally.
- **Unified Workspace Modal:** Built a new `WorkspaceModal.tsx` UI component that acts as the command center for this feature. It provides:
    - An input and button to save the current pipeline configuration.
    - An aesthetically pleasing scrolling library of previously saved workspaces, displaying the template's name and creation date.
    - Contextual actions to "Load" or "Delete" specific templates.
- **Toolbar Integration:** Added a "Workspace" button with layout iconography directly adjacent to the "Share Pipeline" button inside `Toolbar.tsx`.
- **Strict Context Resetting:** Implemented robust state-clearing logic when loading a template. Fetching a saved workspace will automatically clear the canvas via `workspace.clear()` and explicitly clear the uploaded image via `pipelineStore.clearImage()`. This guarantees zero bleeding of data or execution errors from previously run pipelines.

**## How to Test**

1. Run the frontend dev server: `npm run dev`
2. Drag a few functional blocks onto the Blockly canvas (e.g., Read Image, Grayscale).
3. Click the newly added **Workspace** button in the top menu.
4. In the modal, name the pipeline (e.g., "Grayscale Test") and hit **Save**. Note it instantly appears in the list below.
5. Clear the canvas or hit the "New" button.
6. Re-open the Workspace modal, locate "Grayscale Test", and click **Load**. Confirm the pop-up warning.
7. Verify that the exact block configuration, along with any modified sliders/inputs, is perfectly restored and the uploaded image is wiped clean ready for a fresh pipeline run.

**## Video**


https://github.com/user-attachments/assets/512016ab-d0a4-4060-b69c-d2fb3a7256f7


