### PR TITLE
Fix uint8 overflow in Laplacian operator

### DIFF
--- a/imagelab-backend/app/operators/transformation/laplacian.py
+++ b/imagelab-backend/app/operators/transformation/laplacian.py
@@ -21,4 +21,4 @@ class Laplacian(BaseOperator):
             raise ValueError(f"Invalid ksize={ksize}; must be one of {sorted(_VALID_KSIZE)}")
 
         laplacian = cv2.Laplacian(image, ddepth, ksize=ksize)
-        return np.uint8(np.absolute(laplacian))
+        return cv2.convertScaleAbs(laplacian)

--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/tests/operators/transformation/test_laplacian.py
+++ b/imagelab-backend/tests/operators/transformation/test_laplacian.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from app.operators.transformation.laplacian import Laplacian
+
+# Black image with a bright white square – creates strong edges for Laplacian.
+_IMG = np.zeros((64, 64), dtype=np.uint8)
+_IMG[16:48, 16:48] = 255
+
+
+class TestLaplacian:
+    def test_output_dtype_and_range(self):
+        result = Laplacian({}).compute(_IMG)
+        assert result.dtype == np.uint8
+        assert result.min() >= 0 and result.max() <= 255
+
+    def test_no_uint8_wrap_around(self):
+        result = Laplacian({}).compute(_IMG)
+        # Edge pixels must be bright, not dark from modulo wrapping.
+        edge_value = result[16, 32]
+        interior_value = result[32, 32]
+        assert edge_value > interior_value
+
+    def test_ksize_3(self):
+        result = Laplacian({"ksize": 3}).compute(_IMG)
+        assert result.dtype == np.uint8
+        assert result.max() <= 255

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -80,9 +80,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,


### PR DESCRIPTION
## Description

Fix incorrect uint8 conversion in the Laplacian operator.

The previous implementation used:
```python
np.uint8(np.absolute(laplacian))
```
which wraps values modulo 256, leading to incorrect edge intensities (strong edges could appear darker than weaker ones).

This PR replaces it with:
```python
cv2.convertScaleAbs(laplacian)
```
which correctly computes the absolute value and saturates to [0, 255], ensuring accurate edge detection consistent with OpenCV standards.

Fixes #236 

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## How Has This Been Tested?

- Manually tested with images containing strong edges
- Verified that output no longer shows wrapping artifacts
- Confirmed results are consistent with expected Laplacian behavior

- [ ] Existing tests pass
- [x] New tests added
- [x] Manual testing

---

## Screenshots (if applicable)

N/A

---

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally