### PR TITLE
feat: add Laplacian edge detection operator with unit tests

### DIFF
--- a/imagelab-backend/app/operators/filtering/laplacian.py
+++ b/imagelab-backend/app/operators/filtering/laplacian.py
@@ -1,0 +1,34 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class Laplacian(BaseOperator):
+    """
+    Laplacian edge detection operator.
+
+    Applies the Laplacian second-derivative operator to detect edges.
+    Complements Sobel/Canny by using a single kernel for both horizontal
+    and vertical edges simultaneously.
+
+    Params:
+        ksize (int): Aperture size for the Laplacian kernel. Must be odd.
+                     1 = 3x3 kernel (default), 3, 5, 7 also valid.
+    """
+
+    def __init__(self, params: dict):
+        self._ksize = int(params.get("ksize", 1))
+
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if image.ndim == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+
+        if image.ndim == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image.copy()
+
+        lap = cv2.Laplacian(gray, cv2.CV_64F, ksize=self._ksize)
+        result = np.uint8(np.absolute(lap))
+        return result

--- a/imagelab-backend/app/operators/filtering/laplacian.py
+++ b/imagelab-backend/app/operators/filtering/laplacian.py
@@ -24,10 +24,7 @@ class Laplacian(BaseOperator):
         if image.ndim == 3 and image.shape[2] == 4:
             image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
 
-        if image.ndim == 3:
-            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        else:
-            gray = image.copy()
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image.copy()
 
         lap = cv2.Laplacian(gray, cv2.CV_64F, ksize=self._ksize)
         result = np.uint8(np.absolute(lap))

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -32,6 +32,8 @@ from app.operators.filtering.contour_detection import ContourDetection
 from app.operators.filtering.dilation import Dilation
 from app.operators.filtering.erosion import Erosion
 from app.operators.filtering.gabor_filter import GaborFilter
+from app.operators.filtering.laplacian import Laplacian
+from app.operators.filtering.laplacian import Laplacian as FilteringLaplacian
 from app.operators.filtering.morphological import Morphological
 from app.operators.filtering.pyramid_down import PyramidDown
 from app.operators.filtering.pyramid_up import PyramidUp
@@ -52,8 +54,6 @@ from app.operators.thresholding.apply_borders import ApplyBorders
 from app.operators.thresholding.apply_threshold import ApplyThreshold
 from app.operators.thresholding.otsu_threshold import OtsuThreshold
 from app.operators.transformation.distance_transform import DistanceTransform
-from app.operators.transformation.laplacian import Laplacian
-from app.operators.filtering.laplacian import Laplacian
 
 OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     # Basic
@@ -121,7 +121,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "segmentation_watershed": Watershed,
     "segmentation_kmeans": KMeansSegmentation,
     "segmentation_meanshift": MeanShiftSegmentation,
-    "laplacian": Laplacian,
+    "laplacian": FilteringLaplacian,
 }
 
 

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -53,6 +53,7 @@ from app.operators.thresholding.apply_threshold import ApplyThreshold
 from app.operators.thresholding.otsu_threshold import OtsuThreshold
 from app.operators.transformation.distance_transform import DistanceTransform
 from app.operators.transformation.laplacian import Laplacian
+from app.operators.filtering.laplacian import Laplacian
 
 OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     # Basic
@@ -120,6 +121,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     "segmentation_watershed": Watershed,
     "segmentation_kmeans": KMeansSegmentation,
     "segmentation_meanshift": MeanShiftSegmentation,
+    "laplacian": Laplacian,
 }
 
 

--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -10,6 +10,7 @@ from app.operators.filtering.morphological import Morphological
 from app.operators.filtering.pyramid_down import PyramidDown
 from app.operators.filtering.pyramid_up import PyramidUp
 from app.operators.filtering.sharpen import Sharpen
+from app.operators.filtering.laplacian import Laplacian
 
 
 @pytest.fixture
@@ -36,7 +37,8 @@ class TestBilateralFilter:
         assert result.shape == color_image.shape
 
     def test_custom_params_output_shape(self, color_image):
-        result = BilateralFilter({"filterSize": 9, "sigmaColor": 50, "sigmaSpace": 50}).compute(color_image)
+        result = BilateralFilter(
+            {"filterSize": 9, "sigmaColor": 50, "sigmaSpace": 50}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_grayscale_input(self, grayscale_image):
@@ -61,15 +63,18 @@ class TestBoxFilter:
         assert result.shape == color_image.shape
 
     def test_custom_params_output_shape(self, color_image):
-        result = BoxFilter({"width": 10, "height": 10, "depth": -1}).compute(color_image)
+        result = BoxFilter(
+            {"width": 10, "height": 10, "depth": -1}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_grayscale_input(self, grayscale_image):
-        result = BoxFilter({"width": 5, "height": 5, "depth": -1}).compute(grayscale_image)
+        result = BoxFilter(
+            {"width": 5, "height": 5, "depth": -1}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
 
     def test_custom_anchor_point(self, color_image):
-        result = BoxFilter({"width": 5, "height": 5, "depth": -1, "point_x": 0, "point_y": 0}).compute(color_image)
+        result = BoxFilter({"width": 5, "height": 5, "depth": -1,
+                           "point_x": 0, "point_y": 0}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_output_is_uint8(self, color_image):
@@ -244,3 +249,41 @@ class TestPyramidDown:
     def test_output_is_uint8(self, color_image):
         result = PyramidDown({}).compute(color_image)
         assert result.dtype == np.uint8
+
+
+# Laplacian
+
+
+class TestLaplacian:
+    def test_default_params_output_shape(self, color_image):
+        result = Laplacian({}).compute(color_image)
+        assert result.shape[:2] == color_image.shape[:2]
+
+    def test_grayscale_input(self, grayscale_image):
+        result = Laplacian({}).compute(grayscale_image)
+        assert result.shape == grayscale_image.shape
+
+    def test_rgba_input_handled(self, rgba_image):
+        result = Laplacian({}).compute(rgba_image)
+        assert result.shape[:2] == rgba_image.shape[:2]
+
+    def test_output_is_uint8(self, color_image):
+        result = Laplacian({}).compute(color_image)
+        assert result.dtype == np.uint8
+
+    def test_custom_ksize(self, color_image):
+        result = Laplacian({"ksize": 3}).compute(color_image)
+        assert result.shape[:2] == color_image.shape[:2]
+
+    def test_detects_edges(self):
+        # Flat image should produce near-zero Laplacian response
+        flat = np.ones((50, 50, 3), dtype=np.uint8) * 128
+        result = Laplacian({}).compute(flat)
+        assert result.sum() == 0
+
+    def test_edge_image_produces_nonzero_response(self):
+        # Image with sharp edge should produce nonzero response
+        edge_image = np.zeros((50, 50, 3), dtype=np.uint8)
+        edge_image[:, 25:] = 255
+        result = Laplacian({}).compute(edge_image)
+        assert result.sum() > 0

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -6,11 +6,11 @@ from app.operators.filtering.bilateral_filter import BilateralFilter
 from app.operators.filtering.box_filter import BoxFilter
 from app.operators.filtering.dilation import Dilation
 from app.operators.filtering.erosion import Erosion
+from app.operators.filtering.laplacian import Laplacian
 from app.operators.filtering.morphological import Morphological
 from app.operators.filtering.pyramid_down import PyramidDown
 from app.operators.filtering.pyramid_up import PyramidUp
 from app.operators.filtering.sharpen import Sharpen
-from app.operators.filtering.laplacian import Laplacian
 
 
 @pytest.fixture
@@ -37,8 +37,7 @@ class TestBilateralFilter:
         assert result.shape == color_image.shape
 
     def test_custom_params_output_shape(self, color_image):
-        result = BilateralFilter(
-            {"filterSize": 9, "sigmaColor": 50, "sigmaSpace": 50}).compute(color_image)
+        result = BilateralFilter({"filterSize": 9, "sigmaColor": 50, "sigmaSpace": 50}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_grayscale_input(self, grayscale_image):
@@ -63,18 +62,15 @@ class TestBoxFilter:
         assert result.shape == color_image.shape
 
     def test_custom_params_output_shape(self, color_image):
-        result = BoxFilter(
-            {"width": 10, "height": 10, "depth": -1}).compute(color_image)
+        result = BoxFilter({"width": 10, "height": 10, "depth": -1}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_grayscale_input(self, grayscale_image):
-        result = BoxFilter(
-            {"width": 5, "height": 5, "depth": -1}).compute(grayscale_image)
+        result = BoxFilter({"width": 5, "height": 5, "depth": -1}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
 
     def test_custom_anchor_point(self, color_image):
-        result = BoxFilter({"width": 5, "height": 5, "depth": -1,
-                           "point_x": 0, "point_y": 0}).compute(color_image)
+        result = BoxFilter({"width": 5, "height": 5, "depth": -1, "point_x": 0, "point_y": 0}).compute(color_image)
         assert result.shape == color_image.shape
 
     def test_output_is_uint8(self, color_image):
@@ -85,9 +81,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,


### PR DESCRIPTION
## Description

Adds a Laplacian edge detection operator to the filtering category using cv2.Laplacian. This operator detects edges using the second-derivative approach, complementing the existing Sobel/Scharr operators with a single-kernel alternative for both horizontal and vertical edges.
Relevant to the GSoC 2026 proposal for per-step visual previews — Laplacian is a commonly used intermediate step in image processing pipelines that students benefit from inspecting in isolation.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran the full filtering operator test suite locally:
python -m pytest tests/test_filtering_operators.py -v
Result: 50 passed in 0.34s

7 new tests added covering:
- Output shape for color, grayscale, and RGBA inputs
- Output dtype (uint8)
- Custom ksize parameter
- Zero response on flat image
- Nonzero response on image with sharp edge

- [x] Existing tests pass
- [x] New tests added

## Screenshots 
<img width="1046" height="898" alt="image" src="https://github.com/user-attachments/assets/ab88178a-c5ca-4412-89cd-8684471e6837" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
