### PR TITLE
feat: implement visual pipeline debugger

### DIFF
--- a/imagelab-backend/app/models/pipeline.py
+++ b/imagelab-backend/app/models/pipeline.py
@@ -4,12 +4,14 @@ from pydantic import BaseModel
 class PipelineStep(BaseModel):
     type: str
     params: dict = {}
+    id: str | None = None
 
 
 class PipelineRequest(BaseModel):
     image: str
     image_format: str = "png"
     pipeline: list[PipelineStep]
+    debug: bool = False
 
 
 class StepTiming(BaseModel):
@@ -23,6 +25,16 @@ class PipelineTimings(BaseModel):
     steps: list[StepTiming]
 
 
+class DebugStepState(BaseModel):
+    """Snapshot of the image after a single operator executes."""
+
+    step: int
+    block_id: str | None = None
+    operator_type: str
+    image: str
+    duration_ms: float
+
+
 class PipelineResponse(BaseModel):
     success: bool
     image: str | None = None
@@ -30,3 +42,4 @@ class PipelineResponse(BaseModel):
     error: str | None = None
     step: int | None = None
     timings: PipelineTimings | None = None
+    debug_states: list[DebugStepState] | None = None

--- a/imagelab-backend/app/services/pipeline_executor.py
+++ b/imagelab-backend/app/services/pipeline_executor.py
@@ -1,10 +1,45 @@
 import time
 
-from app.models.pipeline import PipelineRequest, PipelineResponse, PipelineTimings, StepTiming
+import cv2
+import numpy as np
+
+from app.models.pipeline import (
+    DebugStepState,
+    PipelineRequest,
+    PipelineResponse,
+    PipelineTimings,
+    StepTiming,
+)
 from app.operators.registry import get_operator
 from app.utils.image import decode_base64_image, encode_image_base64
 
 NOOP_TYPES = {"basic_readimage", "basic_writeimage", "border_for_all", "border_each_side"}
+
+DEBUG_ENCODE_FORMAT = "jpeg"
+DEBUG_JPEG_QUALITY = 70
+MAX_DEBUG_DIM = 512
+MAX_DEBUG_STEPS = 25
+
+
+def _thumbnail_for_debug(image: np.ndarray) -> np.ndarray:
+    """Resize image to fit within MAX_DEBUG_DIM for compact debug snapshots."""
+    h, w = image.shape[:2]
+    if max(h, w) <= MAX_DEBUG_DIM:
+        return image
+    scale = MAX_DEBUG_DIM / max(h, w)
+    new_w, new_h = int(w * scale), int(h * scale)
+    return cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
+
+def _encode_debug_image(image: np.ndarray) -> str:
+    """Encode an intermediate image as a compressed JPEG thumbnail."""
+    thumb = _thumbnail_for_debug(image)
+    # Ensure the image has 3 channels for JPEG encoding
+    if len(thumb.shape) == 2:
+        thumb = cv2.cvtColor(thumb, cv2.COLOR_GRAY2BGR)
+    elif thumb.shape[2] == 4:
+        thumb = cv2.cvtColor(thumb, cv2.COLOR_BGRA2BGR)
+    return encode_image_base64(thumb, DEBUG_ENCODE_FORMAT, quality=DEBUG_JPEG_QUALITY)
 
 
 # Thread-safety: this function is safe to call concurrently from FastAPI's
@@ -22,6 +57,7 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
     """
     t_start_total = time.perf_counter()
     step_timings: list[StepTiming] = []
+    debug_states: list[DebugStepState] = []
 
     try:
         image = decode_base64_image(request.image)
@@ -32,6 +68,18 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             error=f"Failed to decode image: {e}",
             step=0,
             timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
+        )
+
+    # Step 0: capture the original decoded image as the "before anything" state
+    if request.debug:
+        debug_states.append(
+            DebugStepState(
+                step=0,
+                block_id=None,
+                operator_type="original",
+                image=_encode_debug_image(image),
+                duration_ms=0.0,
+            )
         )
 
     for i, step in enumerate(request.pipeline):
@@ -46,6 +94,7 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
                 error=f"Unknown operator '{step.type}' at step {i + 1}",
                 step=i + 1,
                 timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
+                debug_states=debug_states if request.debug else None,
             )
 
         try:
@@ -53,9 +102,20 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             operator = operator_cls(step.params)
             image = operator.compute(image)
             t_step_end = time.perf_counter()
-            step_timings.append(
-                StepTiming(step=i + 1, operator_type=step.type, duration_ms=(t_step_end - t_step_start) * 1000)
-            )
+            step_ms = (t_step_end - t_step_start) * 1000
+            step_timings.append(StepTiming(step=i + 1, operator_type=step.type, duration_ms=step_ms))
+
+            # Debug injection: capture this step's output
+            if request.debug and len(debug_states) < MAX_DEBUG_STEPS:
+                debug_states.append(
+                    DebugStepState(
+                        step=i + 1,
+                        block_id=step.id,
+                        operator_type=step.type,
+                        image=_encode_debug_image(image),
+                        duration_ms=step_ms,
+                    )
+                )
         except Exception as e:
             t_fail = time.perf_counter()
             return PipelineResponse(
@@ -63,6 +123,7 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
                 error=f"Error in step {i + 1} ({step.type}): {type(e).__name__}: {e}",
                 step=i + 1,
                 timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
+                debug_states=debug_states if request.debug else None,
             )
 
     try:
@@ -75,6 +136,7 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             error=error_msg,
             step=len(request.pipeline),
             timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
+            debug_states=debug_states if request.debug else None,
         )
 
     t_end_total = time.perf_counter()
@@ -84,4 +146,5 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
         image=encoded,
         image_format=request.image_format,
         timings=PipelineTimings(total_ms=(t_end_total - t_start_total) * 1000, steps=step_timings),
+        debug_states=debug_states if request.debug else None,
     )

--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/app/utils/image.py
+++ b/imagelab-backend/app/utils/image.py
@@ -13,8 +13,15 @@ def decode_base64_image(b64: str) -> np.ndarray:
     return image
 
 
-def encode_image_base64(image: np.ndarray, fmt: str = "png") -> str:
-    success, buf = cv2.imencode(f".{fmt}", image)
+def encode_image_base64(image: np.ndarray, fmt: str = "png", quality: int | None = None) -> str:
+    params = []
+    if quality is not None:
+        if fmt.lower() in ("jpg", "jpeg"):
+            params = [cv2.IMWRITE_JPEG_QUALITY, quality]
+        elif fmt.lower() == "webp":
+            params = [cv2.IMWRITE_WEBP_QUALITY, quality]
+
+    success, buf = cv2.imencode(f".{fmt}", image, params)
     if not success:
         raise ValueError(f"Could not encode image as {fmt}")
     return base64.b64encode(buf).decode("utf-8")

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -80,9 +80,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,

--- a/imagelab-frontend/src/components/Layout.tsx
+++ b/imagelab-frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useBlocklyWorkspace } from "../hooks/useBlocklyWorkspace";
 import { usePipelineStore } from "../store/pipelineStore";
 import Navbar from "./Navbar";
@@ -10,8 +10,39 @@ import { ErrorBoundary } from "./ErrorBoundary";
 
 export default function Layout() {
   const { containerRef, workspace } = useBlocklyWorkspace();
-  const { reset } = usePipelineStore();
+  const { reset, isDebugActive, debugStates, debugCursor } = usePipelineStore();
   const [resetKey, setResetKey] = useState(0);
+
+  // Apply visual highlighting to blocks during debug mode
+  useEffect(() => {
+    if (!workspace) return;
+
+    // First, remove highlight from all blocks
+    const allBlocks = workspace.getAllBlocks(false);
+    allBlocks.forEach((block) => {
+      const svgRoot = block.getSvgRoot();
+      if (svgRoot) {
+        svgRoot.classList.remove("debug-highlighted-block");
+      }
+    });
+
+    // Then, if debug is active and we have a valid block, highlight it
+    if (isDebugActive && debugStates && debugStates.length > 0) {
+      const currentState = debugStates[debugCursor];
+      if (currentState && currentState.block_id) {
+        const activeBlock = workspace.getBlockById(currentState.block_id);
+        if (activeBlock) {
+          const svgRoot = activeBlock.getSvgRoot();
+          if (svgRoot) {
+            svgRoot.classList.add("debug-highlighted-block");
+
+            // Optional: Scroll to the block
+            // workspace.centerOnBlock(currentState.block_id);
+          }
+        }
+      }
+    }
+  }, [workspace, isDebugActive, debugStates, debugCursor]);
 
   const handleEditorReset = () => {
     setResetKey((prev) => prev + 1);

--- a/imagelab-frontend/src/components/Preview/DebugScrubber.tsx
+++ b/imagelab-frontend/src/components/Preview/DebugScrubber.tsx
@@ -1,0 +1,92 @@
+import { usePipelineStore } from "../../store/pipelineStore";
+import { ChevronLeft, ChevronRight, X, Play } from "lucide-react";
+
+export default function DebugScrubber() {
+  const { debugStates, debugCursor, stepForward, stepBackward, exitDebug } = usePipelineStore();
+
+  if (!debugStates || debugStates.length === 0) return null;
+
+  const currentState = debugStates[debugCursor];
+
+  return (
+    <div className="flex flex-col h-full bg-gray-50 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 bg-white border-b border-amber-200">
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center w-5 h-5 rounded bg-amber-100 text-amber-700 text-xs font-bold font-mono">
+            {debugCursor}
+          </span>
+          <span className="text-sm font-semibold text-gray-700 font-mono">
+            {currentState.operator_type}
+          </span>
+        </div>
+        <button
+          onClick={exitDebug}
+          className="p-1 hover:bg-gray-100 rounded text-gray-400 hover:text-gray-600 transition-colors"
+          title="Exit Debug Mode (Esc)"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Image Display */}
+      <div className="flex-1 flex items-center justify-center p-4 min-h-0 overflow-auto">
+        <img
+          src={`data:image/jpeg;base64,${currentState.image}`}
+          alt={`Debug step ${debugCursor}`}
+          className="max-w-full max-h-full object-contain shadow-sm border border-gray-200 rounded"
+        />
+      </div>
+
+      {/* Footer / Scrubber Controls */}
+      <div className="p-3 bg-white border-t border-gray-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={stepBackward}
+            disabled={debugCursor === 0}
+            className="p-1.5 rounded hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent text-gray-600 transition-colors"
+            title="Previous Step (Left Arrow)"
+          >
+            <ChevronLeft size={20} />
+          </button>
+
+          <div className="flex-1 relative flex items-center group cursor-pointer h-6">
+            {/* Scrubber track */}
+            <div className="absolute left-0 right-0 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-amber-400 rounded-full transition-all duration-200"
+                style={{
+                  width: `${(debugCursor / Math.max(1, debugStates.length - 1)) * 100}%`,
+                }}
+              />
+            </div>
+            {/* Interactive ticks */}
+            <div className="absolute inset-x-0 inset-y-0 flex justify-between items-center px-1">
+              {debugStates.map((_, i) => (
+                <div
+                  key={i}
+                  className={`w-1.5 h-1.5 rounded-full z-10 transition-colors duration-200 ${
+                    i <= debugCursor ? "bg-amber-600" : "bg-gray-300"
+                  } ${i === debugCursor ? "ring-4 ring-amber-100 scale-150" : ""}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          <button
+            onClick={stepForward}
+            disabled={debugCursor === debugStates.length - 1}
+            className="p-1.5 rounded hover:bg-gray-100 disabled:opacity-30 disabled:hover:bg-transparent text-gray-600 transition-colors"
+            title="Next Step (Right Arrow)"
+          >
+            {debugCursor === debugStates.length - 1 ? (
+              <Play size={20} />
+            ) : (
+              <ChevronRight size={20} />
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/components/Preview/PreviewPane.tsx
+++ b/imagelab-frontend/src/components/Preview/PreviewPane.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ZoomIn, ZoomOut, Image, ImageDown, Trash2, Timer } from "lucide-react";
 import { usePipelineStore } from "../../store/pipelineStore";
 import ImageDisplay from "./ImageDisplay";
+import DebugScrubber from "./DebugScrubber";
 
 function ZoomControls({
   disabled,
@@ -41,8 +42,16 @@ function getStepLabel(operatorType: string): string {
 }
 
 export default function PreviewPane() {
-  const { originalImage, imageFormat, processedImage, error, errorStep, clearImage, timings } =
-    usePipelineStore();
+  const {
+    originalImage,
+    imageFormat,
+    processedImage,
+    error,
+    errorStep,
+    clearImage,
+    timings,
+    isDebugActive,
+  } = usePipelineStore();
   const [originalZoom, setOriginalZoom] = useState<number | null>(null);
   const [processedZoom, setProcessedZoom] = useState<number | null>(null);
 
@@ -82,8 +91,14 @@ export default function PreviewPane() {
         />
       </div>
 
-      {/* Processed image — bottom half */}
-      <div className="flex-1 flex flex-col min-h-0">
+      {/* Processed image or Debug Scrubber — bottom half */}
+      <div className="flex-1 flex flex-col min-h-0 relative">
+        {isDebugActive ? (
+          <div className="absolute inset-0 z-10 flex flex-col bg-white">
+            <DebugScrubber />
+          </div>
+        ) : null}
+
         <div className="flex items-center justify-between px-3 py-1.5 border-b border-gray-200">
           <div className="flex items-center gap-1.5">
             <ImageDown size={14} className="text-gray-400" />

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import * as Blockly from "blockly";
-import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2 } from "lucide-react";
+import { FilePlus, Download, Undo2, Redo2, Play, Loader2, Share2, Bug, BugOff } from "lucide-react";
 import { usePipelineStore } from "../store/pipelineStore";
 import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
@@ -31,6 +31,13 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     uniqueBlockTypes,
     categoryCounts,
     complexity,
+    debugMode,
+    isDebugActive,
+    setDebugMode,
+    setDebugStates,
+    stepForward,
+    stepBackward,
+    exitDebug,
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
@@ -72,12 +79,16 @@ export default function Toolbar({ workspace }: ToolbarProps) {
         image: originalImage,
         image_format: imageFormat,
         pipeline,
+        debug: debugMode,
       });
 
       setTiming(response.timings ?? null);
 
       if (response.success && response.image) {
         setProcessedImage(response.image);
+        if (debugMode && response.debug_states && response.debug_states.length > 0) {
+          setDebugStates(response.debug_states);
+        }
       } else {
         setError(response.error || "Pipeline execution failed", response.step);
       }
@@ -95,6 +106,11 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     onDownload: handleDownload,
     onUndo: handleUndo,
     onRedo: handleRedo,
+    onDebugToggle: () => setDebugMode(!debugMode),
+    onDebugStepForward: stepForward,
+    onDebugStepBackward: stepBackward,
+    onDebugExit: exitDebug,
+    isDebugActive,
     workspace,
   });
 
@@ -135,6 +151,18 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           title="Share Pipeline"
         >
           <Share2 size={18} />
+        </button>
+
+        <div className={separator} />
+
+        <button
+          onClick={() => setDebugMode(!debugMode)}
+          className={`p-1.5 rounded transition-colors ${
+            debugMode ? "bg-amber-100 text-amber-700" : "hover:bg-gray-100 text-gray-500"
+          }`}
+          title={`Toggle Debug Mode (${mod}D)`}
+        >
+          {debugMode ? <Bug size={18} /> : <BugOff size={18} />}
         </button>
 
         <div className={separator} />

--- a/imagelab-frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/imagelab-frontend/src/hooks/useKeyboardShortcuts.ts
@@ -6,6 +6,11 @@ interface ShortcutHandlers {
   onDownload: () => void;
   onUndo: () => void;
   onRedo: () => void;
+  onDebugStepForward?: () => void;
+  onDebugStepBackward?: () => void;
+  onDebugExit?: () => void;
+  onDebugToggle?: () => void;
+  isDebugActive?: boolean;
   workspace: Blockly.WorkspaceSvg | null;
 }
 
@@ -25,11 +30,42 @@ export function useKeyboardShortcuts({
   onDownload,
   onUndo,
   onRedo,
+  onDebugStepForward,
+  onDebugStepBackward,
+  onDebugExit,
+  onDebugToggle,
+  isDebugActive,
   workspace,
 }: ShortcutHandlers) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const meta = e.ctrlKey || e.metaKey;
+
+      if (!isTypingInBlockly()) {
+        if (e.key === "d" || e.key === "D") {
+          e.preventDefault();
+          onDebugToggle?.();
+          return;
+        }
+
+        if (isDebugActive) {
+          if (e.key === "ArrowRight") {
+            e.preventDefault();
+            onDebugStepForward?.();
+            return;
+          }
+          if (e.key === "ArrowLeft") {
+            e.preventDefault();
+            onDebugStepBackward?.();
+            return;
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onDebugExit?.();
+            return;
+          }
+        }
+      }
 
       // Delete/Backspace: remove selected Blockly block (not when typing)
       if ((e.key === "Delete" || e.key === "Backspace") && !isTypingInBlockly()) {
@@ -78,5 +114,16 @@ export function useKeyboardShortcuts({
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [onRun, onDownload, onUndo, onRedo, workspace]);
+  }, [
+    onRun,
+    onDownload,
+    onUndo,
+    onRedo,
+    onDebugStepForward,
+    onDebugStepBackward,
+    onDebugExit,
+    onDebugToggle,
+    isDebugActive,
+    workspace,
+  ]);
 }

--- a/imagelab-frontend/src/hooks/usePipeline.ts
+++ b/imagelab-frontend/src/hooks/usePipeline.ts
@@ -31,7 +31,7 @@ export function extractPipeline(workspace: Blockly.WorkspaceSvg): PipelineStep[]
         });
       }
     });
-    pipeline.push({ type: block.type, params });
+    pipeline.push({ type: block.type, params, id: block.id });
     block = block.getNextBlock();
   }
   return pipeline;

--- a/imagelab-frontend/src/index.css
+++ b/imagelab-frontend/src/index.css
@@ -47,3 +47,19 @@
 .blocklyScrollbarVertical {
   display: none !important;
 }
+
+/* Debug Mode Block Highlight */
+.debug-highlighted-block {
+  animation: debugPulse 1.5s infinite alternate;
+}
+
+@keyframes debugPulse {
+  0% {
+    filter: drop-shadow(0 0 4px rgba(245, 158, 11, 0.4))
+      drop-shadow(0 0 10px rgba(245, 158, 11, 0.2));
+  }
+  100% {
+    filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.8))
+      drop-shadow(0 0 20px rgba(245, 158, 11, 0.4));
+  }
+}

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import * as Blockly from "blockly";
 import { categories } from "../blocks/categories";
-import type { PipelineTimings } from "../types/pipeline";
+import type { PipelineTimings, DebugStepState } from "../types/pipeline";
 
 interface PipelineState {
   originalImage: string | null;
@@ -19,6 +19,13 @@ interface PipelineState {
   uniqueBlockTypes: number;
   categoryCounts: Record<string, number>;
   complexity: "Low" | "Medium" | "High";
+
+  // Debug mode
+  debugMode: boolean;
+  debugStates: DebugStepState[];
+  debugCursor: number;
+  isDebugActive: boolean;
+
   setOriginalImage: (image: string, format: string) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
@@ -30,6 +37,14 @@ interface PipelineState {
   clearImage: () => void;
   _imageResetFn: (() => void) | null;
   registerImageReset: (fn: () => void) => void;
+
+  // Debug actions
+  setDebugMode: (on: boolean) => void;
+  setDebugStates: (states: DebugStepState[]) => void;
+  setDebugCursor: (cursor: number) => void;
+  stepForward: () => void;
+  stepBackward: () => void;
+  exitDebug: () => void;
 }
 
 function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" | "High" {
@@ -39,7 +54,7 @@ function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" |
   return "Low";
 }
 
-export const usePipelineStore = create<PipelineState>((set) => ({
+export const usePipelineStore = create<PipelineState>((set, get) => ({
   originalImage: null,
   imageFormat: "png",
   processedImage: null,
@@ -53,6 +68,13 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   uniqueBlockTypes: 0,
   categoryCounts: {},
   complexity: "Low",
+
+  // Debug mode defaults
+  debugMode: false,
+  debugStates: [],
+  debugCursor: 0,
+  isDebugActive: false,
+
   setOriginalImage: (image, format) =>
     set({
       originalImage: image,
@@ -78,6 +100,9 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       error: null,
       errorStep: null,
       timings: null,
+      debugStates: [],
+      debugCursor: 0,
+      isDebugActive: false,
     });
   },
   updateBlockStats: (workspace) => {
@@ -121,5 +146,45 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       categoryCounts: {},
       complexity: "Low",
       timings: null,
+      debugMode: false,
+      debugStates: [],
+      debugCursor: 0,
+      isDebugActive: false,
+    }),
+
+  // Debug actions
+  setDebugMode: (on) => set({ debugMode: on }),
+
+  setDebugStates: (states) =>
+    set({
+      debugStates: states,
+      debugCursor: states.length - 1,
+      isDebugActive: true,
+    }),
+
+  setDebugCursor: (cursor) => {
+    const { debugStates } = get();
+    set({ debugCursor: Math.max(0, Math.min(cursor, debugStates.length - 1)) });
+  },
+
+  stepForward: () => {
+    const { debugCursor, debugStates } = get();
+    if (debugCursor < debugStates.length - 1) {
+      set({ debugCursor: debugCursor + 1 });
+    }
+  },
+
+  stepBackward: () => {
+    const { debugCursor } = get();
+    if (debugCursor > 0) {
+      set({ debugCursor: debugCursor - 1 });
+    }
+  },
+
+  exitDebug: () =>
+    set({
+      isDebugActive: false,
+      debugStates: [],
+      debugCursor: 0,
     }),
 }));

--- a/imagelab-frontend/src/types/pipeline.ts
+++ b/imagelab-frontend/src/types/pipeline.ts
@@ -1,12 +1,14 @@
 export interface PipelineStep {
   type: string;
   params: Record<string, unknown>;
+  id?: string;
 }
 
 export interface PipelineRequest {
   image: string;
   image_format: string;
   pipeline: PipelineStep[];
+  debug?: boolean;
 }
 
 export interface StepTiming {
@@ -20,6 +22,14 @@ export interface PipelineTimings {
   steps: StepTiming[];
 }
 
+export interface DebugStepState {
+  step: number;
+  block_id: string | null;
+  operator_type: string;
+  image: string;
+  duration_ms: number;
+}
+
 export interface PipelineResponse {
   success: boolean;
   image?: string;
@@ -27,4 +37,5 @@ export interface PipelineResponse {
   error?: string;
   step?: number;
   timings?: PipelineTimings;
+  debug_states?: DebugStepState[];
 }


### PR DESCRIPTION
## Feature Description
This PR introduces the **Visual Pipeline Debugger**, allowing users to visually inspect their image processing pipelines step-by-step. By capturing intermediate state images after each operator executes, users can scrub forward and backward through their pipeline history. Corresponding Blockly blocks actively glow on the canvas to help trace execution logic visually.

Fix - #268 

## Full Approach in Detail

The approach relies on modifying the backend to pass back intermediate `DebugStepState` outputs when a `debug=True` flag is appended to the Pipeline Request. Instead of returning raw high-definition PNGs for every intermediate step (which would bloat the response size), the backend compresses these snapshots aggressively. Each is downscaled to a max dimension of 512px and encoded to JPEG with a quality limit of 70. This ensures snappy UI feedback.

On the frontend, the feature pivots around the React `usePipelineStore` (via Zustand). A new `DebugScrubber` UI component intercepts the standard output preview and enables navigation using the `debugCursor` and `debugStates` array. We rely on the `block.id` natively provided by Blockly to match each state with its authoring node, dispatching CSS animations onto the active SVG path in `Layout.tsx` using a React `useEffect` callback without modifying the core blockly library.

## State Diagram

```mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Executing : Click "Run" (Debug On)
    
    state Executing {
        DecodingImage --> ProcessingStep1
        ProcessingStep1 --> CompressThumb1 : Extract State
        CompressThumb1 --> ProcessingStep2
        ProcessingStep2 --> CompressThumb2 : Extract State
        CompressThumb2 --> EncodingFinalImage
    }
    
    Executing --> DebugModeActive : Return PipelineResponse
    Executing --> ErrorState : Operator Error (Return Partial States)
    
    state DebugModeActive {
        ScrubForward
        ScrubBackward
        HighlightActiveBlock
    }
    
    DebugModeActive --> Idle : Exit Debug Mode (Esc)
    ErrorState --> DebugModeActive : Error Intercepted (Debug Rendered)
```

## Task List Implemented

- [x] **Backend**: Update `PipelineStep` to accept optional `id` mapping.
- [x] **Backend**: Update `PipelineRequest` to handle `debug` flag.
- [x] **Backend**: Update `PipelineResponse` to include `debug_states`.
- [x] **Backend**: Add intermediate image capture, resizing (`_thumbnail_for_debug`), and JPEG encoding.
- [x] **Backend**: Update `image.py` to support variable `quality` for JPEG export encoding.
- [x] **Frontend**: Define types for `DebugStepState`.
- [x] **Frontend**: Expand Zustand `usePipelineStore` to manage debug modes, cursor states, and iteration controls.
- [x] **Frontend**: Modify `usePipeline` hook to export `block.id` from Blockly inputs.
- [x] **Frontend**: Develop `DebugScrubber.tsx` component to parse intermediate results visually.
- [x] **Frontend**: Refactor `PreviewPane.tsx` to conditionally render debug UI or standard UI.
- [x] **Frontend**: Implement SVG targeting inside `Layout.tsx` for `.debug-highlighted-block`.
- [x] **Frontend**: Add core Keyboard shortcuts (`Command/Ctrl + D`, `Arrow Left`, `Arrow Right`, `Esc`).

## Manual Testing

1. Launch frontend and backend servers.
2. Ensure you are on the `pipeline` branch.
3. Open the UI, drag an "Image -> Read Image" block onto the canvas.
4. Drag several filters (e.g. `Gaussian Blur`, `Convert to Grayscale`, `Sobel Edge Detection`).
5. Wire all the blocks together to form a legal pipeline.
6. Toggle the Debug icon in the Toolbar (the Bug icon should turn Amber).
7. Execute the Pipeline.
8. Assert that the `DebugScrubber` appears on the right pane instead of a single output.
9. Press `Right Arrow` and `Left Arrow` to scrub through the outputs. Check that the highlighted block on the canvas moves in parallel.
10. Intentionally cause an error (e.g., mismatched type) and verify that all debug states *up to* the error step are successfully returned and navigable.
11. Press `Escape` or the exit button to successfully drop back to standard execution view.

## Video Result


https://github.com/user-attachments/assets/43b7fe5a-3960-40d8-8c21-23df847dc944

