### PR TITLE
feat: Replace window.confirm() with styled ConfirmDialog component

### DIFF
--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -80,9 +80,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,

--- a/imagelab-frontend/src/components/ConfirmDialog.tsx
+++ b/imagelab-frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+
+interface ConfirmDialogProps {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ message, onConfirm, onCancel }: ConfirmDialogProps) {
+  // Close on Escape key — mirrors SharePipelineModal pattern
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-describedby="confirm-dialog-message"
+        className="bg-white rounded-xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Body */}
+        <div className="px-5 py-5">
+          <p id="confirm-dialog-message" className="text-sm text-gray-700 leading-relaxed">
+            {message}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-2 px-5 pb-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-1.5 rounded-lg text-sm font-medium border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-4 py-1.5 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 transition-colors"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/components/SharePipelineModal.tsx
+++ b/imagelab-frontend/src/components/SharePipelineModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import * as Blockly from "blockly";
 import { X, Copy, Check, Share2, Upload } from "lucide-react";
+import ConfirmDialog from "./ConfirmDialog";
 
 const READ_IMAGE_BLOCK_TYPE = "basic_readimage";
 const FILENAME_LABEL_FIELD = "filename_label";
@@ -36,6 +37,7 @@ export default function SharePipelineModal({ workspace, onClose }: SharePipeline
   const [copyError, setCopyError] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadSuccess, setLoadSuccess] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   // Close on Escape key
   useEffect(() => {
@@ -69,17 +71,10 @@ export default function SharePipelineModal({ workspace, onClose }: SharePipeline
     }
   };
 
-  const handleLoad = () => {
-    if (!workspace || !inputCode.trim()) return;
+  const executeLoad = () => {
+    if (!workspace) return;
     setLoadError(null);
     setLoadSuccess(false);
-
-    // Confirm before overwriting existing workspace
-    const existingBlocks = workspace.getAllBlocks(false);
-    if (existingBlocks.length > 0) {
-      if (!window.confirm("Loading a pipeline will replace your current workspace. Continue?"))
-        return;
-    }
 
     try {
       const state = decompressFromCode(inputCode.trim());
@@ -111,141 +106,171 @@ export default function SharePipelineModal({ workspace, onClose }: SharePipeline
     }
   };
 
+  const handleLoad = () => {
+    if (!workspace || !inputCode.trim()) return;
+    setLoadError(null);
+    setLoadSuccess(false);
+
+    // If blocks exist, confirm before overwriting
+    const existingBlocks = workspace.getAllBlocks(false);
+    if (existingBlocks.length > 0) {
+      setShowConfirm(true);
+      return;
+    }
+
+    executeLoad();
+  };
+
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={onClose}
-      role="presentation"
-    >
+    <>
       <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Share Pipeline"
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+        onClick={onClose}
+        role="presentation"
       >
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
-          <div className="flex items-center gap-2">
-            <Share2 size={18} className="text-indigo-500" />
-            <h2 className="text-sm font-semibold text-gray-800">Share Pipeline</h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="p-1 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
-            title="Close"
-            aria-label="Close"
-          >
-            <X size={16} aria-hidden="true" />
-          </button>
-        </div>
-
-        <div className="p-5 space-y-6">
-          {/* Generate section */}
-          <div className="space-y-3">
-            <div>
-              <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
-                Generate Code
-              </p>
-              <p className="text-xs text-gray-500 mt-0.5">
-                Share your current pipeline with others using a code.
-              </p>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Share Pipeline"
+          className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200">
+            <div className="flex items-center gap-2">
+              <Share2 size={18} className="text-indigo-500" />
+              <h2 className="text-sm font-semibold text-gray-800">Share Pipeline</h2>
             </div>
-
             <button
               type="button"
-              onClick={handleGenerate}
-              disabled={!workspace}
-              className="w-full py-2 px-3 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              title="Generate shareable pipeline code"
+              onClick={onClose}
+              className="p-1 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+              title="Close"
+              aria-label="Close"
             >
-              Generate Code
+              <X size={16} aria-hidden="true" />
             </button>
+          </div>
 
-            {generatedCode !== null && (
-              <div className="space-y-2">
-                {generatedCode === "" ? (
-                  <p className="text-xs text-gray-500 italic">
-                    No blocks in workspace. Add some blocks first.
-                  </p>
-                ) : (
-                  <>
-                    <div className="flex gap-2">
-                      <input
-                        readOnly
-                        value={generatedCode}
-                        aria-label="Generated pipeline code"
-                        placeholder="Generated code will appear here"
-                        className="flex-1 text-xs font-mono bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-gray-700 truncate"
-                      />
-                      <button
-                        type="button"
-                        onClick={handleCopy}
-                        className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border border-gray-200 hover:bg-gray-50 transition-colors text-gray-600"
-                        title="Copy code to clipboard"
-                        aria-label="Copy code to clipboard"
-                      >
-                        {copied ? (
-                          <Check size={14} className="text-green-500" aria-hidden="true" />
-                        ) : (
-                          <Copy size={14} aria-hidden="true" />
-                        )}
-                        {copied ? "Copied!" : "Copy"}
-                      </button>
-                    </div>
-                    {copyError && <p className="text-xs text-red-500">{copyError}</p>}
-                    <p className="text-[11px] text-gray-400">
-                      Anyone with this code can load your pipeline.
-                    </p>
-                  </>
-                )}
+          <div className="p-5 space-y-6">
+            {/* Generate section */}
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+                  Generate Code
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Share your current pipeline with others using a code.
+                </p>
               </div>
-            )}
-          </div>
 
-          <div className="border-t border-gray-100" />
+              <button
+                type="button"
+                onClick={handleGenerate}
+                disabled={!workspace}
+                className="w-full py-2 px-3 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                title="Generate shareable pipeline code"
+              >
+                Generate Code
+              </button>
 
-          {/* Load section */}
-          <div className="space-y-3">
-            <div>
-              <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
-                Load from Code
-              </p>
-              <p className="text-xs text-gray-500 mt-0.5">
-                Paste a pipeline code to load it into your workspace.
-              </p>
+              {generatedCode !== null && (
+                <div className="space-y-2">
+                  {generatedCode === "" ? (
+                    <p className="text-xs text-gray-500 italic">
+                      No blocks in workspace. Add some blocks first.
+                    </p>
+                  ) : (
+                    <>
+                      <div className="flex gap-2">
+                        <input
+                          readOnly
+                          value={generatedCode}
+                          aria-label="Generated pipeline code"
+                          placeholder="Generated code will appear here"
+                          className="flex-1 text-xs font-mono bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-gray-700 truncate"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleCopy}
+                          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border border-gray-200 hover:bg-gray-50 transition-colors text-gray-600"
+                          title="Copy code to clipboard"
+                          aria-label="Copy code to clipboard"
+                        >
+                          {copied ? (
+                            <Check size={14} className="text-green-500" aria-hidden="true" />
+                          ) : (
+                            <Copy size={14} aria-hidden="true" />
+                          )}
+                          {copied ? "Copied!" : "Copy"}
+                        </button>
+                      </div>
+                      {copyError && <p className="text-xs text-red-500">{copyError}</p>}
+                      <p className="text-[11px] text-gray-400">
+                        Anyone with this code can load your pipeline.
+                      </p>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
 
-            <textarea
-              value={inputCode}
-              onChange={(e) => {
-                setInputCode(e.target.value);
-                setLoadError(null);
-                setLoadSuccess(false);
-              }}
-              aria-label="Paste pipeline code here"
-              placeholder="Paste pipeline code here..."
-              rows={3}
-              className="w-full text-xs font-mono bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-gray-700 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-transparent"
-            />
+            <div className="border-t border-gray-100" />
 
-            {loadError && <p className="text-xs text-red-500">{loadError}</p>}
-            {loadSuccess && <p className="text-xs text-green-600">Pipeline loaded successfully!</p>}
+            {/* Load section */}
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+                  Load from Code
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Paste a pipeline code to load it into your workspace.
+                </p>
+              </div>
 
-            <button
-              type="button"
-              onClick={handleLoad}
-              disabled={!inputCode.trim() || !workspace}
-              className="w-full flex items-center justify-center gap-2 py-2 px-3 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              title="Load pipeline from code"
-            >
-              <Upload size={14} aria-hidden="true" />
-              Load Pipeline
-            </button>
+              <textarea
+                value={inputCode}
+                onChange={(e) => {
+                  setInputCode(e.target.value);
+                  setLoadError(null);
+                  setLoadSuccess(false);
+                }}
+                aria-label="Paste pipeline code here"
+                placeholder="Paste pipeline code here..."
+                rows={3}
+                className="w-full text-xs font-mono bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-gray-700 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:border-transparent"
+              />
+
+              {loadError && <p className="text-xs text-red-500">{loadError}</p>}
+              {loadSuccess && (
+                <p className="text-xs text-green-600">Pipeline loaded successfully!</p>
+              )}
+
+              <button
+                type="button"
+                onClick={handleLoad}
+                disabled={!inputCode.trim() || !workspace}
+                className="w-full flex items-center justify-center gap-2 py-2 px-3 rounded-lg text-sm font-medium text-white bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                title="Load pipeline from code"
+              >
+                <Upload size={14} aria-hidden="true" />
+                Load Pipeline
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {showConfirm && (
+        <ConfirmDialog
+          message="Loading a pipeline will replace your current workspace. Continue?"
+          onConfirm={() => {
+            setShowConfirm(false);
+            executeLoad();
+          }}
+          onCancel={() => setShowConfirm(false)}
+        />
+      )}
+    </>
   );
 }

--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -6,6 +6,7 @@ import { executePipeline } from "../api/pipeline";
 import { extractPipeline } from "../hooks/usePipeline";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import SharePipelineModal from "./SharePipelineModal";
+import ConfirmDialog from "./ConfirmDialog";
 
 interface ToolbarProps {
   workspace: Blockly.WorkspaceSvg | null;
@@ -34,11 +35,14 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   } = usePipelineStore();
 
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const handleNew = () => {
-    if (!window.confirm("This will clear all blocks and the uploaded image. Continue?")) {
-      return;
-    }
+    setShowConfirm(true);
+  };
+
+  const handleNewConfirmed = () => {
+    setShowConfirm(false);
     reset();
     if (workspace) workspace.clear();
   };
@@ -204,6 +208,14 @@ export default function Toolbar({ workspace }: ToolbarProps) {
 
       {showShareModal && (
         <SharePipelineModal workspace={workspace} onClose={() => setShowShareModal(false)} />
+      )}
+
+      {showConfirm && (
+        <ConfirmDialog
+          message="This will clear all blocks and the uploaded image. Continue?"
+          onConfirm={handleNewConfirmed}
+          onCancel={() => setShowConfirm(false)}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Description

Replaces all `window.confirm()` usages with a reusable, styled HTML confirmation modal component (`ConfirmDialog`). The native browser dialog was visually inconsistent with the application's UI and appeared differently across operating systems.

This change introduces a consistent, accessible, and reusable confirmation pattern aligned with the app’s design system.

Fixes #273

---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## How Has This Been Tested?

Manually verified both trigger points in the browser:

* Clicked **New** button in the toolbar → custom HTML modal appeared (not browser dialog) → Cancel keeps workspace, Confirm clears it ✅

* Opened **Share Pipeline** → added code → clicked **Load Pipeline** with existing blocks → custom modal appeared → Cancel aborts, Confirm loads pipeline ✅

* [x] Existing tests pass

* [ ] New tests added

* [x] Manual testing

---

## Screenshots (if applicable)

<img width="1280" height="620" alt="output" src="https://github.com/user-attachments/assets/8645e156-84bc-46ab-a4f4-7a2ac19f32ef" />
<img width="1280" height="623" alt="output1" src="https://github.com/user-attachments/assets/4eff26da-49fb-4b88-bb52-74672e541196" />


---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review
* [ ] I have added/updated documentation as needed
* [x] My changes generate no new warnings
* [x] Tests pass locally
