### PR TITLE
fix(tests): blurring and contour detection tests asserting wrong behaviour

### DIFF
--- a/imagelab-backend/tests/operators/filtering/test_contour_detection.py
+++ b/imagelab-backend/tests/operators/filtering/test_contour_detection.py
@@ -26,9 +26,8 @@ def make_rect_image(channels=3, bg=0, fg=255):
     "params",
     [
         {},  # defaults
-        {"color": "#00FF00", "thickness": 1, "retrieval_mode": "EXTERNAL", "approximation_method": "SIMPLE"},
-        {"color": "#FF0000", "thickness": 2, "retrieval_mode": "TREE", "approximation_method": "NONE"},
-        {"color": "#0000FF", "thickness": 3, "retrieval_mode": "LIST", "approximation_method": "SIMPLE"},
+        {"rgbcolors_input": "#00FF00", "thickness": 1, "mode": "EXTERNAL", "method": "SIMPLE"},
+        {"rgbcolors_input": "#FF0000", "thickness": 2, "mode": "TREE", "method": "NONE"},
     ],
 )
 def test_contour_detection_returns_valid_image(params):
@@ -50,8 +49,10 @@ def test_contour_detection_supports_gray_bgr_bgra(channels):
 
     result = op.compute(image.copy())
 
-    if channels == 4:
-        assert result.shape == (100, 100, 3)  # BGRA -> BGR conversion path
+    if channels == 1:
+        assert result.shape == (100, 100, 3)  # grayscale -> BGR conversion for drawing
+    elif channels == 4:
+        assert result.shape == (100, 100, 4)  # BGRA preserved, alpha retained
     else:
         assert result.shape == image.shape
 

--- a/imagelab-backend/tests/test_blurring_operators.py
+++ b/imagelab-backend/tests/test_blurring_operators.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from app.operators.blurring.blur import Blur
 from app.operators.blurring.gaussian_blur import GaussianBlur
@@ -56,11 +57,9 @@ class TestGaussianBlur:
         result = GaussianBlur({"widthSize": 5, "heightSize": 5}).compute(color_image)
         assert result.shape == color_image.shape
 
-    def test_even_kernel_corrected_to_odd(self, color_image):
-        result_even = GaussianBlur({"widthSize": 4, "heightSize": 4}).compute(color_image)
-        result_odd = GaussianBlur({"widthSize": 5, "heightSize": 5}).compute(color_image)
-        assert result_even.shape == color_image.shape
-        np.testing.assert_array_equal(result_even, result_odd)
+    def test_even_kernel_raises(self, color_image):
+        with pytest.raises(ValueError, match="even"):
+            GaussianBlur({"widthSize": 4, "heightSize": 4}).compute(color_image)
 
     def test_grayscale_input(self, grayscale_image):
         result = GaussianBlur({}).compute(grayscale_image)
@@ -102,11 +101,9 @@ class TestMedianBlur:
         result = MedianBlur({"kernelSize": 5}).compute(color_image)
         assert result.shape == color_image.shape
 
-    def test_even_kernel_corrected_to_odd(self, color_image):
-        result_even = MedianBlur({"kernelSize": 4}).compute(color_image)
-        result_odd = MedianBlur({"kernelSize": 5}).compute(color_image)
-        assert result_even.shape == color_image.shape
-        np.testing.assert_array_equal(result_even, result_odd)
+    def test_even_kernel_raises(self, color_image):
+        with pytest.raises(ValueError, match="even"):
+            MedianBlur({"kernelSize": 4}).compute(color_image)
 
     def test_grayscale_input(self, grayscale_image):
         result = MedianBlur({}).compute(grayscale_image)
@@ -129,9 +126,9 @@ class TestMedianBlur:
             np.abs(result.astype(int) - clean.astype(int)).mean() < np.abs(noisy.astype(int) - clean.astype(int)).mean()
         )
 
-    def test_kernel_size_1_is_identity(self, color_image):
-        result = MedianBlur({"kernelSize": 1}).compute(color_image)
-        np.testing.assert_array_equal(result, color_image)
+    def test_kernel_size_1_raises(self, color_image):
+        with pytest.raises(ValueError, match="kernelSize"):
+            MedianBlur({"kernelSize": 1}).compute(color_image)
 
     def test_small_image_no_crash(self):
         img = np.zeros((3, 3, 3), dtype=np.uint8)


### PR DESCRIPTION
## Description

The blurring operators were updated at some point to validate kernel sizes strictly instead of silently correcting them, but the tests weren't updated to match. `test_even_kernel_corrected_to_odd` for both `GaussianBlur` and `MedianBlur` were trying to call the operators with even sizes and asserting the output equalled the next-odd result — but both operators now raise `ValueError` for even inputs. Same with `test_kernel_size_1_is_identity` for `MedianBlur`: the validator rejects `kernelSize=1` (min is 3). Rewrote all three to assert the `ValueError` is raised, which is what the validators actually guarantee.

The contour detection test had two separate problems. First, the parametrized cases were passing the wrong key names — `color`, `retrieval_mode`, `approximation_method` instead of the operator's actual param keys `rgbcolors_input`, `mode`, `method`. The wrong keys were silently ignored so the tests were passing while exercising nothing. Also removed the `LIST` mode case which isn't in `_MODE_MAP` at all. Second, the channel support test had wrong shape assertions: grayscale input gets converted to BGR for drawing (output is `(H, W, 3)`, not `(H, W)`), and BGRA input is preserved as-is (output `(H, W, 4)`, not `(H, W, 3)`).

Also includes the `color.py` ruff formatting fix (double blank line after import) that main still carries so CI doesn't fail on the unrelated pre-existing violation.

Fixes #282

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran `uv run pytest` — all previously broken tests now pass with correct assertions. Ran `uv run ruff check .` and `uv run ruff format --check .` with no errors.
- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally