### PR TITLE
 fix: ReadImage clear image only resetting the last registered block

### DIFF
--- a/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
+++ b/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
@@ -39,8 +39,7 @@ function initReadImageBlock(block: Blockly.Block) {
     });
   }
 
-  // Register a reset callback when the image is cleared
-  usePipelineStore.getState().registerImageReset(() => {
+  const unregisterImageReset = usePipelineStore.getState().registerImageReset(() => {
     const label = block.getField("filename_label");
     if (label) label.setValue("No image");
   });
@@ -49,6 +48,7 @@ function initReadImageBlock(block: Blockly.Block) {
   block.dispose = new Proxy(block.dispose, {
     apply(target, thisArg, args) {
       fileInput.remove();
+      unregisterImageReset();
       return Reflect.apply(target, thisArg, args);
     },
   });

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -3,6 +3,8 @@ import * as Blockly from "blockly";
 import { categories } from "../blocks/categories";
 import type { PipelineTimings } from "../types/pipeline";
 
+const imageResetListeners = new Set<() => void>();
+
 interface PipelineState {
   originalImage: string | null;
   imageFormat: string;
@@ -28,8 +30,7 @@ interface PipelineState {
   updateBlockStats: (workspace: Blockly.WorkspaceSvg) => void;
   reset: () => void;
   clearImage: () => void;
-  _imageResetFn: (() => void) | null;
-  registerImageReset: (fn: () => void) => void;
+  registerImageReset: (fn: () => void) => () => void;
 }
 
 function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" | "High" {
@@ -67,11 +68,14 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   setSelectedBlock: (type, tooltip) =>
     set({ selectedBlockType: type, selectedBlockTooltip: tooltip }),
   setTiming: (timings) => set({ timings }),
-  _imageResetFn: null as (() => void) | null,
-  registerImageReset: (fn) => set({ _imageResetFn: fn }),
+  registerImageReset: (fn) => {
+    imageResetListeners.add(fn);
+    return () => {
+      imageResetListeners.delete(fn);
+    };
+  },
   clearImage: () => {
-    const state = usePipelineStore.getState();
-    if (state._imageResetFn) state._imageResetFn();
+    imageResetListeners.forEach((fn) => fn());
     set({
       originalImage: null,
       processedImage: null,
@@ -106,7 +110,8 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       complexity: calculateComplexity(blocks.length, uniqueTypes.size),
     });
   },
-  reset: () =>
+  reset: () => {
+    imageResetListeners.clear();
     set({
       originalImage: null,
       imageFormat: "png",
@@ -121,5 +126,6 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       categoryCounts: {},
       complexity: "Low",
       timings: null,
-    }),
+    });
+  },
 }));

--- a/imagelab-frontend/tests/store/pipelineStore.test.ts
+++ b/imagelab-frontend/tests/store/pipelineStore.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePipelineStore } from "../../src/store/pipelineStore";
+
+beforeEach(() => {
+  usePipelineStore.getState().reset();
+});
+
+describe("registerImageReset", () => {
+  it("calls all registered listeners when clearImage is invoked", () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+
+    usePipelineStore.getState().registerImageReset(fn1);
+    usePipelineStore.getState().registerImageReset(fn2);
+    usePipelineStore.getState().clearImage();
+
+    expect(fn1).toHaveBeenCalledOnce();
+    expect(fn2).toHaveBeenCalledOnce();
+  });
+
+  it("does not call the same function twice when registered once", () => {
+    const fn = vi.fn();
+
+    usePipelineStore.getState().registerImageReset(fn);
+    usePipelineStore.getState().clearImage();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("returned unsubscribe removes the listener so it is not called on clearImage", () => {
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+
+    const unregister = usePipelineStore.getState().registerImageReset(fn1);
+    usePipelineStore.getState().registerImageReset(fn2);
+
+    unregister();
+    usePipelineStore.getState().clearImage();
+
+    expect(fn1).not.toHaveBeenCalled();
+    expect(fn2).toHaveBeenCalledOnce();
+  });
+
+  it("listeners persist across multiple clearImage calls until unsubscribed", () => {
+    const fn = vi.fn();
+
+    usePipelineStore.getState().registerImageReset(fn);
+    usePipelineStore.getState().clearImage();
+    usePipelineStore.getState().clearImage();
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("reset", () => {
+  it("clears all listeners so clearImage does not call them after reset", () => {
+    const fn = vi.fn();
+
+    usePipelineStore.getState().registerImageReset(fn);
+    usePipelineStore.getState().reset();
+    usePipelineStore.getState().clearImage();
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("allows fresh listeners registered after reset to fire normally", () => {
+    const stale = vi.fn();
+    const fresh = vi.fn();
+
+    usePipelineStore.getState().registerImageReset(stale);
+    usePipelineStore.getState().reset();
+    usePipelineStore.getState().registerImageReset(fresh);
+    usePipelineStore.getState().clearImage();
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledOnce();
+  });
+});
+
+describe("clearImage", () => {
+  it("resets image-related state fields", () => {
+    usePipelineStore.getState().setOriginalImage("base64data", "png");
+    usePipelineStore.getState().setProcessedImage("processed");
+    usePipelineStore.getState().setError("some error", 2);
+
+    usePipelineStore.getState().clearImage();
+
+    const state = usePipelineStore.getState();
+    expect(state.originalImage).toBeNull();
+    expect(state.processedImage).toBeNull();
+    expect(state.error).toBeNull();
+    expect(state.errorStep).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description

`_imageResetFn` was stored as a plain Zustand state value, so every `registerImageReset` call overwrote the previous one. With two `ReadImage` blocks, only the second one's label ever reset on "Clear Image". Functions in Zustand state also break React DevTools serialisation.

Replaced `_imageResetFn` with a module-level `Set<() => void>` that lives outside Zustand. `registerImageReset` now adds to the Set and returns an unsubscribe function. `clearImage` iterates the whole Set, so every live `ReadImage` block gets its label reset. `reset()` clears the Set so stale callbacks from a previous session don't survive a workspace reset.

The extension was updated to store the returned unsubscribe and call it inside the existing disposal Proxy, so the Set doesn't accumulate dead callbacks from deleted blocks.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Ran unit tests, integration tests, and manual testing in the browser with and without the backend running. Verified that with two `ReadImage` blocks on the workspace, clicking "Clear Image" now resets both blocks' labels instead of only the last registered one.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Related issue:
Fixes #285 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally