### PR TITLE
Added persistence for original image

### DIFF
--- a/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
+++ b/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
@@ -25,8 +25,7 @@ function initReadImageBlock(block: Blockly.Block) {
     reader.onload = () => {
       const dataUrl = reader.result as string;
       const base64 = dataUrl.split(",")[1];
-      usePipelineStore.getState().setOriginalImage(base64, format);
-      setFilenameLabel(block, file.name);
+      usePipelineStore.getState().setOriginalImage(base64, format, file.name);
     };
     reader.readAsDataURL(file);
 
@@ -50,14 +49,24 @@ function initReadImageBlock(block: Blockly.Block) {
           return;
         }
 
-        usePipelineStore.getState().setOriginalImage(image, format);
-        setFilenameLabel(block, label);
+        usePipelineStore.getState().setOriginalImage(image, format, label);
       });
     });
   }
 
+  const unregisterImageLabelSync = usePipelineStore
+    .getState()
+    .registerImageLabelSync((filename) => {
+      setFilenameLabel(block, filename ?? "No image");
+    });
+
+  const persistedFilename = usePipelineStore.getState().imageFilename;
+  if (persistedFilename) {
+    setFilenameLabel(block, persistedFilename);
+  }
+
   // Register a reset callback when the image is cleared
-  usePipelineStore.getState().registerImageReset(() => {
+  const unregisterImageReset = usePipelineStore.getState().registerImageReset(() => {
     setFilenameLabel(block, "No image");
   });
 
@@ -67,6 +76,8 @@ function initReadImageBlock(block: Blockly.Block) {
       fileInput.remove();
       // Clear image from store when read_image block is deleted
       usePipelineStore.getState().clearImage();
+      unregisterImageLabelSync();
+      unregisterImageReset();
       return Reflect.apply(target, thisArg, args);
     },
   });

--- a/imagelab-frontend/src/hooks/imagePersistence.ts
+++ b/imagelab-frontend/src/hooks/imagePersistence.ts
@@ -1,0 +1,74 @@
+export const IMAGE_STORAGE_KEY = "imagelab.pipeline.image.v1";
+export const IMAGE_STORAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_PERSISTED_IMAGE_CHARS = 3_500_000;
+
+export interface PersistedImageState {
+  image: string;
+  format: string;
+  filename: string | null;
+}
+
+type PersistedPayload<T> = {
+  expiresAt?: number;
+  data?: T;
+};
+
+export function loadPersistedImageState(
+  storage: Storage = localStorage,
+  key = IMAGE_STORAGE_KEY,
+): PersistedImageState | null {
+  const raw = storage.getItem(key);
+  if (!raw) return null;
+
+  try {
+    const payload = JSON.parse(raw) as PersistedPayload<PersistedImageState>;
+    if (
+      typeof payload.expiresAt !== "number" ||
+      Date.now() > payload.expiresAt ||
+      !payload.data ||
+      typeof payload.data.image !== "string" ||
+      typeof payload.data.format !== "string" ||
+      (payload.data.filename !== null && typeof payload.data.filename !== "string")
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return payload.data;
+  } catch {
+    storage.removeItem(key);
+    return null;
+  }
+}
+
+export function saveImageState(
+  state: PersistedImageState,
+  storage: Storage = localStorage,
+  key = IMAGE_STORAGE_KEY,
+  ttlMs = IMAGE_STORAGE_TTL_MS,
+): boolean {
+  if (state.image.length > MAX_PERSISTED_IMAGE_CHARS) {
+    storage.removeItem(key);
+    console.warn("[ImageLab] Skipping image persistence because the image is too large.");
+    return false;
+  }
+
+  const payload = {
+    expiresAt: Date.now() + ttlMs,
+    data: state,
+  };
+
+  try {
+    storage.setItem(key, JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    console.warn("[ImageLab] Could not persist image state:", err);
+    return false;
+  }
+}
+
+export function clearPersistedImage(
+  storage: Storage = localStorage,
+  key = IMAGE_STORAGE_KEY,
+): void {
+  storage.removeItem(key);
+}

--- a/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
+++ b/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
@@ -7,6 +7,7 @@ import { WorkspaceSearch } from "@blockly/plugin-workspace-search";
 import { usePipelineStore } from "../store/pipelineStore";
 import { imagelabTheme, imagelabThemeDark } from "../blocks/theme";
 import { SINGLETON_BLOCK_TYPES } from "../utils/blockLimits";
+import { loadPersistedImageState } from "./imagePersistence";
 import {
   clearPersistedWorkspace,
   loadPersistedWorkspaceState,
@@ -91,6 +92,13 @@ export function useBlocklyWorkspace({ isDark = false }: UseBlocklyWorkspaceOptio
         console.warn("[ImageLab] Failed to restore workspace state; clearing persisted data.", err);
         clearPersistedWorkspace();
       }
+    }
+
+    const persistedImage = loadPersistedImageState();
+    if (persistedImage) {
+      usePipelineStore
+        .getState()
+        .setOriginalImage(persistedImage.image, persistedImage.format, persistedImage.filename);
     }
 
     ws.addChangeListener((event: Blockly.Events.Abstract) => {

--- a/imagelab-frontend/src/store/pipelineStore.ts
+++ b/imagelab-frontend/src/store/pipelineStore.ts
@@ -2,10 +2,15 @@ import { create } from "zustand";
 import * as Blockly from "blockly";
 import { categories } from "../blocks/categories";
 import type { PipelineTimings } from "../types/pipeline";
+import { clearPersistedImage, saveImageState } from "../hooks/imagePersistence";
+
+const imageResetListeners = new Set<() => void>();
+const imageLabelSyncListeners = new Set<(filename: string | null) => void>();
 
 interface PipelineState {
   originalImage: string | null;
   imageFormat: string;
+  imageFilename: string | null;
   processedImage: string | null;
   isExecuting: boolean;
   error: string | null;
@@ -23,7 +28,7 @@ interface PipelineState {
   uniqueBlockTypes: number;
   categoryCounts: Record<string, number>;
   complexity: "Low" | "Medium" | "High";
-  setOriginalImage: (image: string, format: string) => void;
+  setOriginalImage: (image: string, format: string, filename?: string | null) => void;
   setProcessedImage: (image: string | null) => void;
   setExecuting: (executing: boolean) => void;
   setError: (error: string | null, step?: number | null) => void;
@@ -36,8 +41,8 @@ interface PipelineState {
   updateBlockStats: (workspace: Blockly.WorkspaceSvg) => void;
   reset: () => void;
   clearImage: () => void;
-  _imageResetFn: (() => void) | null;
-  registerImageReset: (fn: () => void) => void;
+  registerImageReset: (fn: () => void) => () => void;
+  registerImageLabelSync: (fn: (filename: string | null) => void) => () => void;
 }
 
 function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" | "High" {
@@ -50,6 +55,7 @@ function calculateComplexity(blocks: number, unique: number): "Low" | "Medium" |
 export const usePipelineStore = create<PipelineState>((set) => ({
   originalImage: null,
   imageFormat: "png",
+  imageFilename: null,
   processedImage: null,
   isExecuting: false,
   error: null,
@@ -63,14 +69,18 @@ export const usePipelineStore = create<PipelineState>((set) => ({
   uniqueBlockTypes: 0,
   categoryCounts: {},
   complexity: "Low",
-  setOriginalImage: (image, format) =>
+  setOriginalImage: (image, format, filename = null) => {
+    imageLabelSyncListeners.forEach((listener) => listener(filename));
+    saveImageState({ image, format, filename });
     set({
       originalImage: image,
       imageFormat: format,
+      imageFilename: filename,
       processedImage: null,
       error: null,
       timings: null,
-    }),
+    });
+  },
   setProcessedImage: (image) => set({ processedImage: image, error: null, errorStep: null }),
   setExecuting: (executing) => set({ isExecuting: executing }),
   setError: (error, step = null) => set({ error, errorStep: step }),
@@ -87,13 +97,26 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       isCameraModalOpen: false,
       cameraCaptureHandler: null,
     }),
-  _imageResetFn: null as (() => void) | null,
-  registerImageReset: (fn) => set({ _imageResetFn: fn }),
+  registerImageReset: (fn) => {
+    imageResetListeners.add(fn);
+    return () => {
+      imageResetListeners.delete(fn);
+    };
+  },
+  registerImageLabelSync: (fn) => {
+    imageLabelSyncListeners.add(fn);
+    return () => {
+      imageLabelSyncListeners.delete(fn);
+    };
+  },
   clearImage: () => {
-    const state = usePipelineStore.getState();
-    if (state._imageResetFn) state._imageResetFn();
+    imageResetListeners.forEach((listener) => listener());
+    imageLabelSyncListeners.forEach((listener) => listener(null));
+    clearPersistedImage();
     set({
       originalImage: null,
+      imageFormat: "png",
+      imageFilename: null,
       processedImage: null,
       error: null,
       errorStep: null,
@@ -128,10 +151,16 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       complexity: calculateComplexity(blocks.length, uniqueTypes.size),
     });
   },
-  reset: () =>
+  reset: () => {
+    imageResetListeners.forEach((listener) => listener());
+    imageLabelSyncListeners.forEach((listener) => listener(null));
+    imageResetListeners.clear();
+    imageLabelSyncListeners.clear();
+    clearPersistedImage();
     set({
       originalImage: null,
       imageFormat: "png",
+      imageFilename: null,
       processedImage: null,
       isExecuting: false,
       error: null,
@@ -145,5 +174,6 @@ export const usePipelineStore = create<PipelineState>((set) => ({
       timings: null,
       isCameraModalOpen: false,
       cameraCaptureHandler: null,
-    }),
+    });
+  },
 }));

--- a/imagelab-frontend/tests/hooks/imagePersistence.test.ts
+++ b/imagelab-frontend/tests/hooks/imagePersistence.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPersistedImage,
+  IMAGE_STORAGE_KEY,
+  loadPersistedImageState,
+  saveImageState,
+} from "../../src/hooks/imagePersistence";
+
+class LocalStorageMock implements Storage {
+  public readonly store = new Map<string, string>();
+  public throwOnSet = false;
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.throwOnSet) {
+      const err = new Error("Quota exceeded");
+      err.name = "QuotaExceededError";
+      throw err;
+    }
+    this.store.set(key, value);
+  }
+}
+
+describe("loadPersistedImageState", () => {
+  let storage: LocalStorageMock;
+
+  beforeEach(() => {
+    storage = new LocalStorageMock();
+  });
+
+  it("returns null for expired entries and removes the key", () => {
+    storage.setItem(
+      IMAGE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() - 1000,
+        data: { image: "abc", format: "png", filename: "cat.png" },
+      }),
+    );
+
+    const result = loadPersistedImageState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(IMAGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes the key for malformed JSON", () => {
+    storage.setItem(IMAGE_STORAGE_KEY, "{not-json");
+
+    const result = loadPersistedImageState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(IMAGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and removes the key for invalid payloads", () => {
+    storage.setItem(
+      IMAGE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 60_000,
+        data: { image: "abc", filename: "cat.png" },
+      }),
+    );
+
+    const result = loadPersistedImageState(storage);
+
+    expect(result).toBeNull();
+    expect(storage.getItem(IMAGE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns image state when payload is valid and unexpired", () => {
+    const state = { image: "abc123", format: "png", filename: "cat.png" };
+    storage.setItem(
+      IMAGE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 60_000,
+        data: state,
+      }),
+    );
+
+    const result = loadPersistedImageState(storage);
+
+    expect(result).toEqual(state);
+  });
+});
+
+describe("saveImageState", () => {
+  let storage: LocalStorageMock;
+
+  beforeEach(() => {
+    storage = new LocalStorageMock();
+  });
+
+  it("writes payload with expiresAt in the future", () => {
+    const state = { image: "abc123", format: "png", filename: "cat.png" };
+    const now = Date.now();
+    const ok = saveImageState(state, storage, IMAGE_STORAGE_KEY, 10_000);
+
+    expect(ok).toBe(true);
+    const raw = storage.getItem(IMAGE_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+
+    const payload = JSON.parse(raw!) as { expiresAt: number; data: typeof state };
+    expect(payload.data).toEqual(state);
+    expect(payload.expiresAt).toBeGreaterThanOrEqual(now + 10_000);
+  });
+
+  it("does not throw when localStorage throws QuotaExceededError", () => {
+    storage.throwOnSet = true;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => saveImageState({ image: "abc", format: "png", filename: null }, storage)).not.toThrow();
+    expect(saveImageState({ image: "abc", format: "png", filename: null }, storage)).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  it("skips oversized images", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ok = saveImageState(
+      { image: "a".repeat(3_500_001), format: "png", filename: "huge.png" },
+      storage,
+    );
+
+    expect(ok).toBe(false);
+    expect(storage.getItem(IMAGE_STORAGE_KEY)).toBeNull();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("clearPersistedImage", () => {
+  it("removes the persisted key", () => {
+    const storage = new LocalStorageMock();
+    storage.setItem(
+      IMAGE_STORAGE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 1,
+        data: { image: "abc", format: "png", filename: "cat.png" },
+      }),
+    );
+
+    clearPersistedImage(storage);
+
+    expect(storage.getItem(IMAGE_STORAGE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
On app startup, the persisted image should be restored into the pipeline store and the Read Image block label should reflect the restored file name, so the editor returns to the same usable state as before reload. The persistence should be best-effort, with validation, expiry handling, and cleanup for invalid or oversized payloads.

Fixes #287 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

Before
https://github.com/user-attachments/assets/24733c14-afe9-41ce-8a55-e5096a130065

After
https://github.com/user-attachments/assets/4cc534e2-a01c-4de7-9ea0-519b0b481610



## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
