### PR TITLE
fix(drawing): clamp negative radius to 0 in DrawCircle

### DIFF
--- a/imagelab-backend/app/operators/drawing/draw_circle.py
+++ b/imagelab-backend/app/operators/drawing/draw_circle.py
@@ -9,7 +9,7 @@ class DrawCircle(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         result = image.copy()
         thickness = int(self.params.get("thickness", 2))
-        radius = int(self.params.get("radius", 5))
+        radius = max(0, int(self.params.get("radius", 5)))
         color = hex_to_bgr(self.params.get("rgbcolors_input", "#2828cc"))
         cx = int(self.params.get("center_point_x", 0))
         cy = int(self.params.get("center_point_y", 0))

--- a/imagelab-backend/tests/test_drawing_operators.py
+++ b/imagelab-backend/tests/test_drawing_operators.py
@@ -1,3 +1,4 @@
+import cv2
 import numpy as np
 import pytest
 
@@ -103,6 +104,21 @@ class TestDrawCircle:
         result = DrawCircle({}).compute(grayscale_image)
         assert result.shape == grayscale_image.shape
         assert result.dtype == np.uint8
+
+    def test_negative_radius_is_clamped_to_zero(self):
+        blank = np.zeros((100, 100, 3), dtype=np.uint8)
+        params = {
+            "center_point_x": 50,
+            "center_point_y": 50,
+            "radius": -10,
+            "rgbcolors_input": "#ff0000",
+            "thickness": 1,
+        }
+
+        result = DrawCircle(params).compute(blank)
+        expected = cv2.circle(blank.copy(), (50, 50), 0, (0, 0, 255), 1)
+
+        np.testing.assert_array_equal(result, expected)
 
 
 class TestDrawEllipse:


### PR DESCRIPTION
## Description
`DrawCircle` had no validation on the `radius` parameter. Passing a negative radius value to `cv2.circle()` causes a crash. Added `max(0, ...)` clamping to ensure the radius never reaches OpenCV as a negative value.

Fixes #222

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

Verified that passing negative radius values no longer crashes the pipeline and instead renders a zero-radius circle (point).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally