### PR TITLE
fix(transformation): handle BGRA images and add configurable maskSize in DistanceTransform

### DIFF
--- a/imagelab-backend/app/operators/transformation/distance_transform.py
+++ b/imagelab-backend/app/operators/transformation/distance_transform.py
@@ -9,19 +9,29 @@ DISTANCE_TYPES = {
     "DIST_L2": cv2.DIST_L2,
 }
 
+MASK_SIZES = {3: 3, 5: 5}
+
 
 class DistanceTransform(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         dist_name = self.params.get("type", "DIST_L2")
         dist_type = DISTANCE_TYPES.get(dist_name, cv2.DIST_L2)
 
-        # Convert to grayscale if needed
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
+        mask_size_param = int(self.params.get("maskSize", 5))
+        mask_size = MASK_SIZES.get(mask_size_param, 5)
+
+        # Convert to grayscale based on number of channels
+        if len(image.shape) == 3:
+            if image.shape[2] == 4:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image
 
         # Threshold to get binary image
         _, binary = cv2.threshold(gray, 127, 255, cv2.THRESH_BINARY)
-
-        dist = cv2.distanceTransform(binary, dist_type, maskSize=5)
+        dist = cv2.distanceTransform(binary, dist_type, maskSize=mask_size)
 
         # Normalize to 0-255 uint8 for display
         cv2.normalize(dist, dist, 0, 255, cv2.NORM_MINMAX)


### PR DESCRIPTION
## Description
The `DistanceTransform` operator had two problems:
1. Used `cv2.COLOR_BGR2GRAY` for all multi-channel images — crashes on BGRA (4-channel) input
2. `maskSize` was hardcoded to `5` — not user-configurable

Fixes #263

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Added BGRA channel detection before grayscale conversion and introduced a configurable `maskSize` parameter accepting values 3 or 5 (defaults to 5).

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally