### PR TITLE
fix: keep Blockly workspace controls visible when info pane resizes. Fixes #226

### DIFF
--- a/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
+++ b/imagelab-frontend/src/hooks/useBlocklyWorkspace.ts
@@ -34,6 +34,7 @@ type WorkspaceState = ReturnType<typeof Blockly.serialization.workspaces.save>;
 export function useBlocklyWorkspace() {
   const containerRef = useRef<HTMLDivElement>(null);
   const workspaceRef = useRef<Blockly.WorkspaceSvg | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const saveTimeoutRef = useRef<number | null>(null);
   const [workspace, setWorkspace] = useState<Blockly.WorkspaceSvg | null>(null);
   const setSelectedBlock = usePipelineStore((s) => s.setSelectedBlock);
@@ -131,6 +132,14 @@ export function useBlocklyWorkspace() {
 
     workspaceRef.current = ws;
     setWorkspace(ws);
+    Blockly.svgResize(ws);
+    if (containerRef.current && typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(() => {
+        Blockly.svgResize(ws);
+      });
+      observer.observe(containerRef.current);
+      resizeObserverRef.current = observer;
+    }
     updateBlockStats(ws); // Initial stats calculation if any blocks loaded
   }, [setSelectedBlock, updateBlockStats]);
 
@@ -138,6 +147,10 @@ export function useBlocklyWorkspace() {
     initWorkspace();
     return () => {
       // Cleanup on unmount: dispose workspace and clear any pending save timeout
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
       if (saveTimeoutRef.current !== null) {
         window.clearTimeout(saveTimeoutRef.current);
         saveTimeoutRef.current = null;


### PR DESCRIPTION
## Description
Fixes overlap between Blockly workspace controls (zoom/trash/center) and the block info panel by resizing Blockly whenever the workspace container dimensions change. Implemented a `ResizeObserver` in `useBlocklyWorkspace` and triggers `Blockly.svgResize(ws)` on container resize and initial mount.

Fixes #226

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Existing tests pass
- [x] Manual testing

Verified with `npx eslint src/hooks/useBlocklyWorkspace.ts` and `npm run build` — no errors.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally