### PR TITLE
fix(filtering): clamp iteration and add configurable kernel in Dilation and Erosion

### DIFF
--- a/imagelab-backend/app/operators/filtering/dilation.py
+++ b/imagelab-backend/app/operators/filtering/dilation.py
@@ -6,10 +6,13 @@ from app.operators.base import BaseOperator
 
 class Dilation(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        iteration = int(self.params.get("iteration", 1))
+        iteration = max(1, int(self.params.get("iteration", 1)))
         point_x = int(self.params.get("point_x", -1))
         point_y = int(self.params.get("point_y", -1))
-        kernel = np.ones((5, 5), np.uint8)
+        kernel_size = max(1, int(self.params.get("kernelSize", 5)))
+        if kernel_size % 2 == 0:
+            kernel_size += 1
+        kernel = np.ones((kernel_size, kernel_size), np.uint8)
         return cv2.dilate(
             image,
             kernel,

--- a/imagelab-backend/app/operators/filtering/erosion.py
+++ b/imagelab-backend/app/operators/filtering/erosion.py
@@ -6,10 +6,13 @@ from app.operators.base import BaseOperator
 
 class Erosion(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
-        iteration = int(self.params.get("iteration", 1))
+        iteration = max(1, int(self.params.get("iteration", 1)))
         point_x = int(self.params.get("point_x", -1))
         point_y = int(self.params.get("point_y", -1))
-        kernel = np.ones((5, 5), np.uint8)
+        kernel_size = max(1, int(self.params.get("kernelSize", 5)))
+        if kernel_size % 2 == 0:
+            kernel_size += 1
+        kernel = np.ones((kernel_size, kernel_size), np.uint8)
         return cv2.erode(
             image,
             kernel,


### PR DESCRIPTION
## Description
`Dilation` and `Erosion` operators had two problems:
1. Kernel size was hardcoded to `(5, 5)` — not user-configurable
2. `iteration` had no validation — values < 1 crash OpenCV

Fixes #258

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Added `max(1, ...)` clamping to `iteration` and introduced a configurable `kernelSize` parameter (defaults to 5, forced odd) consistent with the `Morphological` operator pattern.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally