### PR TITLE
fix(conversions): fix CLAHE crash on BGRA images

### DIFF
--- a/imagelab-backend/app/operators/conversions/clahe.py
+++ b/imagelab-backend/app/operators/conversions/clahe.py
@@ -34,31 +34,38 @@ class claheImage(BaseOperator):
                 "Convert the image first (e.g. (img * 255).astype(np.uint8))."
             )
         clip_limit = float(self.params.get("clipLimit", 2.0))
-        grid_size = (int(self.params.get("tileGridSizeX", 8)), int(self.params.get("tileGridSizeY", 8)))
+        grid_size = (
+            int(self.params.get("tileGridSizeX", 8)),
+            int(self.params.get("tileGridSizeY", 8)),
+        )
         cache_key = (clip_limit, grid_size)
         if not hasattr(self, "_clahe_cache") or self._clahe_cache[0] != cache_key:
-            self._clahe_cache = (cache_key, cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=grid_size))
+            self._clahe_cache = (
+                cache_key,
+                cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=grid_size),
+            )
         clahe = self._clahe_cache[1]
 
         if len(image.shape) == 3 and image.shape[2] == 3:
-            # Step 1: BGR -> LAB
+            # BGR: apply CLAHE to L channel in LAB space
             lab = cv2.cvtColor(image, cv2.COLOR_BGR2LAB)
             lightness, a, b = cv2.split(lab)
-
-            # Step 2: Apply to 'L' channel
             l_enhanced = clahe.apply(lightness)
-
-            # Step 3: Merge and BGR back
             enhanced_lab = cv2.merge((l_enhanced, a, b))
             return cv2.cvtColor(enhanced_lab, cv2.COLOR_LAB2BGR)
+
         elif image.ndim == 3 and image.shape[2] == 4:
-            # BGRA — apply CLAHE to luminance, preserve alpha
+            # BGRA: apply CLAHE to BGR channels, preserve alpha
             bgr = image[:, :, :3]
             alpha = image[:, :, 3]
-            result_bgr = self._apply_to_bgr(clahe, bgr)
+            lab = cv2.cvtColor(bgr, cv2.COLOR_BGR2LAB)
+            lightness, a, b = cv2.split(lab)
+            l_enhanced = clahe.apply(lightness)
+            enhanced_lab = cv2.merge((l_enhanced, a, b))
+            result_bgr = cv2.cvtColor(enhanced_lab, cv2.COLOR_LAB2BGR)
             return np.dstack([result_bgr, alpha])
+
         else:
-            # Grayscale handling
             # Grayscale (H,W) or (H,W,1)
             gray = image[:, :, 0] if image.ndim == 3 else image
             return clahe.apply(gray)


### PR DESCRIPTION
## Description
The `claheImage` operator called `self._apply_to_bgr(clahe, bgr)` for BGRA images but this method was never defined in the class, causing `AttributeError` on any 4-channel PNG input.

Fixes #254

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally