### PR TITLE
fix(backend): align pipeline error step index with zero-based steps

### DIFF
--- a/imagelab-backend/app/services/pipeline_executor.py
+++ b/imagelab-backend/app/services/pipeline_executor.py
@@ -43,8 +43,8 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             t_fail = time.perf_counter()
             return PipelineResponse(
                 success=False,
-                error=f"Unknown operator '{step.type}' at step {i + 1}",
-                step=i + 1,
+                error=f"Unknown operator '{step.type}' at step {i}",
+                step=i,
                 timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
             )
 
@@ -60,8 +60,8 @@ def execute_pipeline(request: PipelineRequest) -> PipelineResponse:
             t_fail = time.perf_counter()
             return PipelineResponse(
                 success=False,
-                error=f"Error in step {i + 1} ({step.type}): {type(e).__name__}: {e}",
-                step=i + 1,
+                error=f"Error in step {i} ({step.type}): {type(e).__name__}: {e}",
+                step=i,
                 timings=PipelineTimings(total_ms=(t_fail - t_start_total) * 1000, steps=step_timings),
             )
 

--- a/imagelab-backend/tests/test_pipeline_executor.py
+++ b/imagelab-backend/tests/test_pipeline_executor.py
@@ -46,6 +46,7 @@ def test_unknown_operator_gives_clear_error(make_request):
     res = execute_pipeline(make_request([PipelineStep(type="not_a_real_op")]))
     assert res.success is False
     assert res.step == 0
+    assert "at step 0" in res.error
     assert "not_a_real_op" in res.error
     assert "Unknown operator" in res.error
 
@@ -58,6 +59,7 @@ def test_error_includes_correct_step_index(make_request):
     res = execute_pipeline(make_request(steps))
     assert res.success is False
     assert res.step == 1  # first step succeeds, second should fail
+    assert "at step 1" in res.error
     assert "bad_operator_step_one" in res.error
 
 


### PR DESCRIPTION
## Description

This PR fixes off-by-one step indexing for pipeline operator failures in the backend pipeline executor.

Changes made:
- Updated unknown-operator failure path to return zero-based step index (`step=i`).
- Updated runtime-operator failure path to return zero-based step index (`step=i`).
- Updated error message step text to match zero-based indexing.
- Strengthened executor tests by asserting the error message includes the expected step index.

Fixes #245

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- `python -m pytest -q tests/test_pipeline_executor.py`
- `python -m py_compile app\services\pipeline_executor.py tests\test_pipeline_executor.py`

- [x] Existing tests pass
- [ ] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

N/A (backend/API bug fix)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
