### PR TITLE
fix(conversions): convert BGR/BGRA to grayscale before applying colormap

### DIFF
--- a/imagelab-backend/app/operators/conversions/color_maps.py
+++ b/imagelab-backend/app/operators/conversions/color_maps.py
@@ -21,4 +21,12 @@ class ColorMaps(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         colormap_name = self.params.get("type", "HOT")
         colormap = COLORMAP_TYPES.get(colormap_name, cv2.COLORMAP_HOT)
+
+        # cv2.applyColorMap requires a single-channel grayscale image
+        if len(image.shape) == 3:
+            if image.shape[2] == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
         return cv2.applyColorMap(image, colormap)

--- a/imagelab-backend/tests/test_conversion_operators.py
+++ b/imagelab-backend/tests/test_conversion_operators.py
@@ -1,3 +1,4 @@
+import cv2
 import numpy as np
 import pytest
 
@@ -128,6 +129,24 @@ class TestColorMaps:
     def test_output_is_uint8(self, grayscale_image):
         result = ColorMaps({}).compute(grayscale_image)
         assert result.dtype == np.uint8
+
+    def test_bgr_input_is_converted_to_grayscale_before_colormap(self, color_image):
+        result = ColorMaps({"type": "HOT"}).compute(color_image)
+        expected = cv2.applyColorMap(
+            cv2.cvtColor(color_image, cv2.COLOR_BGR2GRAY),
+            cv2.COLORMAP_HOT,
+        )
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_bgra_input_is_converted_to_grayscale_before_colormap(self, rgba_image):
+        result = ColorMaps({"type": "HOT"}).compute(rgba_image)
+        expected = cv2.applyColorMap(
+            cv2.cvtColor(rgba_image, cv2.COLOR_BGRA2GRAY),
+            cv2.COLORMAP_HOT,
+        )
+
+        np.testing.assert_array_equal(result, expected)
 
 
 # ChannelSplit


### PR DESCRIPTION
## Description

`cv2.applyColorMap()` requires a single-channel grayscale image. The `ColorMaps` operator was passing BGR/BGRA images directly, causing incorrect output or crashes.

Fixes #218

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Added grayscale conversion for BGR and BGRA inputs before applying the colormap, consistent with how other operators in the codebase handle multi-channel inputs.