### PR TITLE
fix(geometric): make AffineImage tx/ty configurable via params

### DIFF
--- a/imagelab-backend/app/operators/geometric/affine_image.py
+++ b/imagelab-backend/app/operators/geometric/affine_image.py
@@ -7,5 +7,7 @@ from app.operators.base import BaseOperator
 class AffineImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         rows, cols = image.shape[:2]
-        M = np.float64([[1, 0, 50], [0, 1, 100]])
+        tx = float(self.params.get("tx", 50))
+        ty = float(self.params.get("ty", 100))
+        M = np.float64([[1, 0, tx], [0, 1, ty]])
         return cv2.warpAffine(image, M, (cols, rows))

--- a/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/geometric.blocks.ts
@@ -96,11 +96,15 @@ export const geometricBlocks = [
   },
   {
     type: "geometric_affineimage",
-    message0: "Apply affine transformation",
+    message0: "Apply affine transformation | translate X %1 Y %2",
+    args0: [
+      { type: "field_number", name: "tx", value: 50 },
+      { type: "field_number", name: "ty", value: 100 },
+    ],
     previousStatement: null,
     nextStatement: null,
     style: "geometric_style",
     tooltip:
-      "Applies a fixed affine transformation (translate by 50, 100) - Transforms the image using a predefined affine transformation that translates the image by 50 pixels in the X direction and 100 pixels in the Y direction. This block is useful for demonstrating basic affine transformations, which can include translation, rotation, scaling, and shearing.",
+      "Applies an affine transformation that translates the image by the specified X and Y pixel offsets.",
   },
 ];


### PR DESCRIPTION
**Describe the bug**
`AffineImage` operator had hardcoded translation values (`tx=50, ty=100`) and never read from `self.params`. Users could not configure the transformation at all.

Fixes #300

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Verified that setting custom tx/ty values in the block correctly translates the image by the specified pixel offsets.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally