### PR TITLE
Readme references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,13 @@ A desktop application for visual, block-based image processing using Google Bloc
 
 - [Node.js](https://nodejs.org/) >= 18
 - Python 3.12+
-- PostgreSQL
+- [PostgreSQL](https://www.postgresql.org/download/)
+- [uv](https://github.com/astral-sh/uv) - Python package installer
+  ```bash
+  pip install uv
+  ```
 
 ## Getting Started
-
-### Electron App (Legacy)
-
-```bash
-cd electron-app-legacy
-npm install
-npm start
-```
 
 ### Backend
 
@@ -54,9 +50,6 @@ npm run dev
 ## Running Tests
 
 ```bash
-# Electron app
-cd electron-app-legacy && npm test
-
 # Backend
 cd imagelab-backend && uv run pytest
 
@@ -68,7 +61,6 @@ cd imagelab-frontend && npm run test
 
 ```
 imagelab/
-  electron-app-legacy/   # Original Electron + Blockly app
   imagelab-frontend/     # React + Vite frontend
   imagelab-backend/      # Python FastAPI backend
   docs/                  # Project documentation site


### PR DESCRIPTION
## Summary

This PR fixes critical documentation issues in the README that prevented new contributors from getting started with the project.

## Problem

The README referenced setup instructions for two things that don't exist or aren't documented:

1. The "Getting Started" section instructed users to navigate to `electron-app-legacy/` and run npm commands, but this folder doesn't exist in the repository. Users following these instructions would immediately hit "no such file or directory" errors.

2. The backend setup instructions use `uv sync` as the first command, but `uv` was never listed in the Prerequisites section. This caused "command not found" errors for users who only installed the listed prerequisites (Node.js, Python, and PostgreSQL).

3. The "Project Structure" diagram still showed `electron-app-legacy/` as an existing directory, which was misleading.

## Solution

I made the following changes to README.md:

- Removed the entire "Electron App (Legacy)" getting started section since that folder no longer exists
- Added `uv` to the Prerequisites section with a link to the official repository and pip installation instructions
- Removed the electron app test command from the "Running Tests" section
- Updated the "Project Structure" diagram to only show the directories that actually exist (frontend, backend, and docs)

## Result

The README now accurately reflects the current project structure and all setup instructions will work without errors. New contributors can follow the guide without hitting blockers.