### PR TITLE
fix(conversions): add proper BGRA support in ColorToBinary pipeline

### DIFF
--- a/color_to_binary.py
+++ b/color_to_binary.py
@@ -1,0 +1,25 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+THRESHOLD_TYPES = {
+    "threshold_binary": cv2.THRESH_BINARY,
+    "threshold_binary_inv": cv2.THRESH_BINARY_INV,
+}
+
+
+class ColorToBinary(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        threshold_type_name = self.params.get("thresholdType", "threshold_binary")
+        threshold_type = THRESHOLD_TYPES.get(threshold_type_name, cv2.THRESH_BINARY)
+        threshold_value = float(self.params.get("thresholdValue", 0))
+        max_value = float(self.params.get("maxValue", 0))
+
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+        else:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+        _, dst = cv2.threshold(gray, threshold_value, max_value, threshold_type)
+        return dst

--- a/imagelab-backend/app/operators/conversions/color_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/color_to_binary.py
@@ -15,6 +15,11 @@ class ColorToBinary(BaseOperator):
         threshold_type = THRESHOLD_TYPES.get(threshold_type_name, cv2.THRESH_BINARY)
         threshold_value = float(self.params.get("thresholdValue", 0))
         max_value = float(self.params.get("maxValue", 0))
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+        else:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
         _, dst = cv2.threshold(gray, threshold_value, max_value, threshold_type)
         return dst

--- a/imagelab-backend/app/utils/color.py
+++ b/imagelab-backend/app/utils/color.py
@@ -1,6 +1,5 @@
 import re
 
-
 HEX_COLOR_RE = re.compile(r"^[0-9a-fA-F]{6}$")
 
 
@@ -19,17 +18,13 @@ def hex_to_bgr(hex_color: str) -> tuple[int, int, int]:
         ValueError: If hex_color is not a valid 6-digit hex color string.
     """
     if not isinstance(hex_color, str):
-        raise TypeError(
-            f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}"
-        )
+        raise TypeError(f"hex_to_bgr expects a str, got {type(hex_color).__name__!r}")
 
     original = hex_color
     normalized = hex_color.removeprefix("#")
 
     if not HEX_COLOR_RE.fullmatch(normalized):
-        raise ValueError(
-            f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'."
-        )
+        raise ValueError(f"Invalid hex color: {original!r}. Expected format '#rrggbb' or 'rrggbb'.")
 
     r = int(normalized[0:2], 16)
     g = int(normalized[2:4], 16)

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -80,9 +80,7 @@ class TestBoxFilter:
         image = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
         width, height = 1, 5
 
-        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(
-            image
-        )
+        result = BoxFilter({"width": width, "height": height, "depth": -1}).compute(image)
         expected = cv2.boxFilter(
             image,
             -1,


### PR DESCRIPTION
**Describe the bug**
`ColorToBinary` called `cv2.COLOR_BGR2GRAY` without checking for BGRA (4-channel) input, causing a crash on PNG images with transparency.

Fixes #301

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally