### PR TITLE
fix(geometric): validate fx and fy are positive in ScaleImage

### DIFF
--- a/imagelab-backend/app/operators/geometric/scale_image.py
+++ b/imagelab-backend/app/operators/geometric/scale_image.py
@@ -17,6 +17,11 @@ class ScaleImage(BaseOperator):
         fx = float(self.params.get("fx", 1))
         fy = float(self.params.get("fy", 1))
 
+        if fx <= 0:
+            raise ValueError(f"fx must be positive, got {fx}")
+        if fy <= 0:
+            raise ValueError(f"fy must be positive, got {fy}")
+
         interpolation_str = str(self.params.get("interpolation", "LINEAR")).upper()
         if interpolation_str not in _INTERPOLATION_MAP:
             raise ValueError(


### PR DESCRIPTION
**Describe the bug**
`ScaleImage` passed `fx` and `fy` directly to `cv2.resize()` without validation. Zero or negative scale factors cause an OpenCV crash.

Fixes #302

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

Verified that passing fx=0 or fy=0 now raises a clear ValueError instead of crashing OpenCV.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally