### PR TITLE
fix(conversions): add proper BGRA support in ColorToBinary pipeline

### DIFF
--- a/imagelab-backend/app/operators/conversions/color_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/color_to_binary.py
@@ -15,6 +15,11 @@ class ColorToBinary(BaseOperator):
         threshold_type = THRESHOLD_TYPES.get(threshold_type_name, cv2.THRESH_BINARY)
         threshold_value = float(self.params.get("thresholdValue", 0))
         max_value = float(self.params.get("maxValue", 0))
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+        else:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
         _, dst = cv2.threshold(gray, threshold_value, max_value, threshold_type)
         return dst


### PR DESCRIPTION
**Describe the bug**
`ColorToBinary` called `cv2.COLOR_BGR2GRAY` without checking for BGRA (4-channel) input, causing a crash on PNG images with transparency.

Fixes #301

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally