### PR TITLE
feat(filtering): implement Canny Edge Detection operator

### DIFF
--- a/imagelab-backend/app/operators/filtering/canny_edge.py
+++ b/imagelab-backend/app/operators/filtering/canny_edge.py
@@ -1,0 +1,30 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+
+class CannyEdge(BaseOperator):
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        threshold1 = float(self.params.get("threshold1", 100))
+        threshold2 = float(self.params.get("threshold2", 200))
+        aperture_size = int(self.params.get("apertureSize", 3))
+
+        threshold1 = max(0.0, min(255.0, threshold1))
+        threshold2 = max(0.0, min(255.0, threshold2))
+
+        if aperture_size not in (3, 5, 7):
+            aperture_size = 3
+
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+        elif len(image.shape) == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image.copy()
+
+        if gray.dtype != np.uint8:
+            gray = np.clip(gray, 0, 255).astype(np.uint8)
+
+        edges = cv2.Canny(gray, threshold1, threshold2, apertureSize=aperture_size)
+        return cv2.cvtColor(edges, cv2.COLOR_GRAY2BGR)

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -29,6 +29,7 @@ from app.operators.drawing.draw_rectangle import DrawRectangle
 from app.operators.drawing.draw_text import DrawText
 from app.operators.filtering.bilateral_filter import BilateralFilter
 from app.operators.filtering.box_filter import BoxFilter
+from app.operators.filtering.canny_edge import CannyEdge
 from app.operators.filtering.contour_detection import ContourDetection
 from app.operators.filtering.dilation import Dilation
 from app.operators.filtering.erosion import Erosion
@@ -95,6 +96,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     # Filtering
     "filtering_boxfilter": BoxFilter,
     "filtering_bilateral": BilateralFilter,
+    "filtering_cannyedge": CannyEdge,
     "filtering_sharpen": Sharpen,
     "filtering_pyramidup": PyramidUp,
     "filtering_pyramiddown": PyramidDown,

--- a/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/filtering.blocks.ts
@@ -167,4 +167,26 @@ export const filteringBlocks = [
     style: "filtering_style",
     tooltip: "Detects contours on an image and renders them over the original graphic.",
   },
+  {
+    type: "filtering_cannyedge",
+    message0: "Canny Edge Detection | threshold1 %1 threshold2 %2 aperture %3",
+    args0: [
+      { type: "field_number", name: "threshold1", value: 100, min: 0, max: 255 },
+      { type: "field_number", name: "threshold2", value: 200, min: 0, max: 255 },
+      {
+        type: "field_dropdown",
+        name: "apertureSize",
+        options: [
+          ["3", "3"],
+          ["5", "5"],
+          ["7", "7"],
+        ],
+      },
+    ],
+    previousStatement: null,
+    nextStatement: null,
+    style: "filtering_style",
+    tooltip:
+      "Detects edges in the image using the Canny algorithm. threshold1 and threshold2 are the lower and upper bounds for the hysteresis procedure. apertureSize is the Sobel kernel size.",
+  },
 ];


### PR DESCRIPTION
**Description**
Implements the Canny Edge Detection operator which was already listed in the frontend category block list (`filtering_cannyedge`) but had no backend implementation or block definition.

The operator:
- Accepts configurable `threshold1`, `threshold2` (hysteresis thresholds, 0–255) and `apertureSize` (3, 5, or 7)
- Handles BGR, BGRA, and grayscale input images
- Returns a BGR image with detected edges

Closes #30

## Type of Change
- [x] New feature

## How Has This Been Tested?
- [x] Manual testing

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally