### PR TITLE
Removed original and processed image when read block deleted

### DIFF
--- a/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
+++ b/imagelab-frontend/src/blocks/extensions/readImageExtension.ts
@@ -45,10 +45,12 @@ function initReadImageBlock(block: Blockly.Block) {
     if (label) label.setValue("No image");
   });
 
-  // Clean up on block disposal
+  // Clean up on block disposal (deletion or workspace clear)
   block.dispose = new Proxy(block.dispose, {
     apply(target, thisArg, args) {
       fileInput.remove();
+      // Clear image from store when read_image block is deleted
+      usePipelineStore.getState().clearImage();
       return Reflect.apply(target, thisArg, args);
     },
   });


### PR DESCRIPTION
## Description
When the "Read Image" block is deleted from the Blockly workspace, the original image and processed image remain in the application state. This causes the processed image to persist on screen even after the input block is removed, creating a confusing UX where output exists without an input source.

Fixes #317 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)
<img width="1280" height="562" alt="image" src="https://github.com/user-attachments/assets/772ec2f1-8e17-463e-8b52-59b8e2ae1a7d" />

No blocks but still images are there

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] Tests pass locally
