### PR TITLE
fix(conversions): convert BGR/BGRA to gray before thresholding in GrayToBinary

### DIFF
--- a/imagelab-backend/app/operators/conversions/gray_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/gray_to_binary.py
@@ -6,6 +6,12 @@ from app.operators.base import BaseOperator
 
 class GrayToBinary(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
+        if image.ndim == 3:
+            if image.shape[2] == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
         threshold_value = float(self.params.get("thresholdValue", 0))
         max_value = float(self.params.get("maxValue", 255))
         _, dst = cv2.threshold(image, threshold_value, max_value, cv2.THRESH_BINARY)

--- a/imagelab-backend/tests/operators/conversions/test_gray_to_binary.py
+++ b/imagelab-backend/tests/operators/conversions/test_gray_to_binary.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from app.operators.conversions.gray_to_binary import GrayToBinary
+
+
+def test_gray_to_binary_grayscale_input() -> None:
+    image = np.array([[50, 150]], dtype=np.uint8)
+    out = GrayToBinary({"thresholdValue": 100, "maxValue": 255}).compute(image)
+    assert out.shape == (1, 2)
+    assert out[0, 0] == 0
+    assert out[0, 1] == 255
+
+
+def test_gray_to_binary_bgr_input_converts_first() -> None:
+    image = np.array([[[50, 150, 200]]], dtype=np.uint8)
+    out = GrayToBinary({"thresholdValue": 100, "maxValue": 255}).compute(image)
+    assert out.ndim == 2, "BGR input must produce a single-channel output"
+
+
+def test_gray_to_binary_bgra_input_converts_first() -> None:
+    image = np.array([[[50, 150, 200, 255]]], dtype=np.uint8)
+    out = GrayToBinary({"thresholdValue": 100, "maxValue": 255}).compute(image)
+    assert out.ndim == 2, "BGRA input must produce a single-channel output"
+
+
+def test_gray_to_binary_default_params() -> None:
+    image = np.array([[0, 128, 255]], dtype=np.uint8)
+    out = GrayToBinary({}).compute(image)
+    assert out.ndim == 2
+    assert out[0, 0] == 0
+    assert out[0, 1] == 255
+    assert out[0, 2] == 255


### PR DESCRIPTION
## Description

Fixes `GrayToBinary` silently producing a 3-channel output when given a colour (BGR or BGRA) image instead of a grayscale one.

Previously, `cv2.threshold` ran on each colour channel independently, producing a 3-channel result that was incorrectly labelled as binary. Now the operator converts BGR/BGRA input to grayscale first — consistent with how `ColorToBinary` handles the same case.

Fixes #319

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] New tests added — `tests/operators/conversions/test_gray_to_binary.py`
  - grayscale input works as before
  - BGR input is converted to gray before thresholding (single-channel output)
  - BGRA input is converted to gray before thresholding (single-channel output)
  - default params produce correct binary output
- [x] Existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings
- [x] Tests pass locally