### PR TITLE
Feat/roberts cross operator

### DIFF
--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -49,6 +49,7 @@ from app.operators.geometric.scale_image import ScaleImage
 from app.operators.segmentation.kmeans_segmentation import KMeansSegmentation
 from app.operators.segmentation.mean_shift_segmentation import MeanShiftSegmentation
 from app.operators.segmentation.watershed import Watershed
+from app.operators.sobel_derivatives.roberts_cross import RobertsCross
 from app.operators.sobel_derivatives.prewitt_operator import PrewittOperator
 from app.operators.sobel_derivatives.scharr_derivative import ScharrDerivative
 from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
@@ -119,6 +120,7 @@ OPERATOR_REGISTRY: dict[str, type[BaseOperator]] = {
     # Sobel Derivatives
     "sobelderivatives_soblederivate": SobelDerivative,
     "sobelderivatives_scharrderivate": ScharrDerivative,
+    "sobelderivatives_robertscross": RobertsCross,
     "sobelderivatives_prewittoperator": PrewittOperator,
     # Transformation
     "transformation_distance": DistanceTransform,

--- a/imagelab-backend/app/operators/registry.py
+++ b/imagelab-backend/app/operators/registry.py
@@ -49,8 +49,8 @@ from app.operators.geometric.scale_image import ScaleImage
 from app.operators.segmentation.kmeans_segmentation import KMeansSegmentation
 from app.operators.segmentation.mean_shift_segmentation import MeanShiftSegmentation
 from app.operators.segmentation.watershed import Watershed
-from app.operators.sobel_derivatives.roberts_cross import RobertsCross
 from app.operators.sobel_derivatives.prewitt_operator import PrewittOperator
+from app.operators.sobel_derivatives.roberts_cross import RobertsCross
 from app.operators.sobel_derivatives.scharr_derivative import ScharrDerivative
 from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
 from app.operators.thresholding.adaptive_threshold import AdaptiveThreshold

--- a/imagelab-backend/app/operators/sobel_derivatives/roberts_cross.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/roberts_cross.py
@@ -1,0 +1,23 @@
+import cv2
+import numpy as np
+
+from app.operators.base import BaseOperator
+
+# Roberts Cross kernels — 2x2 diagonal gradient operators
+_KERNEL_X = np.array([[1, 0], [0, -1]], dtype=np.float64)
+_KERNEL_Y = np.array([[0, 1], [-1, 0]], dtype=np.float64)
+
+
+class RobertsCross(BaseOperator):
+    """Applies the Roberts Cross operator to detect edges using diagonal gradients."""
+
+    def compute(self, image: np.ndarray) -> np.ndarray:
+        if image.dtype != np.uint8:
+            raise ValueError(f"RobertsCross expects a uint8 image, got dtype={image.dtype}.")
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
+
+        grad_x = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_X)
+        grad_y = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_Y)
+
+        magnitude = np.sqrt(grad_x**2 + grad_y**2)
+        return np.clip(magnitude, 0, 255).astype(np.uint8)

--- a/imagelab-backend/app/operators/sobel_derivatives/roberts_cross.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/roberts_cross.py
@@ -12,12 +12,36 @@ class RobertsCross(BaseOperator):
     """Applies the Roberts Cross operator to detect edges using diagonal gradients."""
 
     def compute(self, image: np.ndarray) -> np.ndarray:
-        if image.dtype != np.uint8:
-            raise ValueError(f"RobertsCross expects a uint8 image, got dtype={image.dtype}.")
-        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if len(image.shape) == 3 else image
+        """Apply the Roberts Cross edge-detection operator.
 
-        grad_x = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_X)
-        grad_y = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_Y)
+        Args:
+            image: uint8 ndarray of shape (H, W), (H, W, 1), (H, W, 3), or (H, W, 4).
+                   Colour images are converted to grayscale before processing.
+                   Non-uint8 images are normalised to uint8 before processing.
+
+        Returns:
+            uint8 ndarray of shape (H, W) containing gradient magnitudes
+            clipped to [0, 255].
+        """
+        if image.dtype != np.uint8:
+            norm = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX)
+            image = norm.astype(np.uint8)
+
+        if image.ndim == 3:
+            c = image.shape[2]
+            if c == 1:
+                gray = image[:, :, 0]
+            elif c == 3:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            elif c == 4:
+                gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                raise ValueError(f"RobertsCross: unsupported channel count {c}.")
+        else:
+            gray = image
+
+        grad_x = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_X, anchor=(0, 0))
+        grad_y = cv2.filter2D(gray, cv2.CV_64F, _KERNEL_Y, anchor=(0, 0))
 
         magnitude = np.sqrt(grad_x**2 + grad_y**2)
         return np.clip(magnitude, 0, 255).astype(np.uint8)

--- a/imagelab-backend/tests/test_roberts_cross.py
+++ b/imagelab-backend/tests/test_roberts_cross.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from app.operators.sobel_derivatives.roberts_cross import RobertsCross
+
+
+@pytest.fixture
+def op():
+    return RobertsCross(params={})
+
+
+class TestRobertsCrossOutputShape:
+    def test_grayscale_2d(self, op):
+        img = np.zeros((10, 10), dtype=np.uint8)
+        out = op.compute(img)
+        assert out.shape == (10, 10)
+        assert out.dtype == np.uint8
+
+    def test_bgr_3channel(self, op):
+        img = np.zeros((10, 10, 3), dtype=np.uint8)
+        out = op.compute(img)
+        assert out.shape == (10, 10)
+        assert out.dtype == np.uint8
+
+    def test_bgra_4channel(self, op):
+        img = np.zeros((10, 10, 4), dtype=np.uint8)
+        out = op.compute(img)
+        assert out.shape == (10, 10)
+        assert out.dtype == np.uint8
+
+    def test_single_channel_axis(self, op):
+        img = np.zeros((10, 10, 1), dtype=np.uint8)
+        out = op.compute(img)
+        assert out.shape == (10, 10)
+        assert out.dtype == np.uint8
+
+
+class TestRobertsCrossFloatInput:
+    def test_float32_normalised_and_processed(self, op):
+        img = np.random.rand(10, 10, 3).astype(np.float32)
+        out = op.compute(img)
+        assert out.shape == (10, 10)
+        assert out.dtype == np.uint8
+
+
+class TestRobertsCrossEdgeDetection:
+    def test_uniform_image_produces_zero_output(self, op):
+        img = np.full((10, 10), 128, dtype=np.uint8)
+        out = op.compute(img)
+        assert out.max() == 0
+
+    def test_edge_detected_on_step_image(self, op):
+        img = np.zeros((10, 10), dtype=np.uint8)
+        img[:, 5:] = 255
+        out = op.compute(img)
+        assert out.max() > 0
+
+    def test_does_not_mutate_input(self, op):
+        img = np.zeros((10, 10, 3), dtype=np.uint8)
+        original = img.copy()
+        op.compute(img)
+        np.testing.assert_array_equal(img, original)

--- a/imagelab-frontend/src/blocks/categories.ts
+++ b/imagelab-frontend/src/blocks/categories.ts
@@ -145,6 +145,7 @@ export const categories: CategoryInfo[] = [
     blocks: [
       { type: "sobelderivatives_soblederivate", label: "Sobel Derivative" },
       { type: "sobelderivatives_scharrderivate", label: "Scharr Derivative" },
+      { type: "sobelderivatives_robertscross", label: "Roberts Cross" },
       { type: "sobelderivatives_prewittoperator", label: "Prewitt Operator" },
     ],
   },

--- a/imagelab-frontend/src/blocks/definitions/sobel-derivatives.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/sobel-derivatives.blocks.ts
@@ -39,6 +39,15 @@ export const sobelDerivativesBlocks = [
       "Detect edges using Scharr derivative (first order) - Applies the Scharr operator, which is a more accurate first-order derivative operator than Sobel due to its optimized kernel weights. The 'type' parameter specifies the direction: 'Horizontal' detects vertical edges and 'Vertical' detects horizontal edges. The output is always a uint8 image.",
   },
   {
+    type: "sobelderivatives_robertscross",
+    message0: "Apply Roberts Cross edge detection",
+    previousStatement: null,
+    nextStatement: null,
+    style: "sobel_derivatives_style",
+    tooltip:
+      "Detect edges using the Roberts Cross operator - Applies two 2x2 diagonal kernels to compute the gradient magnitude. One of the oldest edge detection operators; works on grayscale images and highlights sharp intensity transitions. Colour images are converted to grayscale automatically.",
+  },
+  {
     type: "sobelderivatives_prewittoperator",
     message0: "Apply Prewitt edge detection",
     previousStatement: null,

--- a/imagelab-frontend/src/data/operatorDocs.ts
+++ b/imagelab-frontend/src/data/operatorDocs.ts
@@ -418,6 +418,18 @@ export const operatorDocs: Record<string, OperatorDoc> = {
       "Fine-grained edge detection on medical or scientific images requiring higher rotational symmetry than Sobel.",
     ],
   },
+  sobelderivatives_robertscross: {
+    name: "Roberts Cross",
+    description:
+      "Applies the Roberts Cross operator to detect edges using two 2x2 diagonal gradient kernels. One of the earliest edge detection operators, sensitive to diagonal edges and sharp transitions.",
+    parameters: [],
+    formula: "G = √(Gx² + Gy²), Gx = [[1,0],[0,-1]], Gy = [[0,1],[-1,0]]",
+    useCases: [
+      "Teaching the fundamentals of gradient-based edge detection.",
+      "Fast edge detection where computational simplicity is preferred over accuracy.",
+      "Detecting diagonal edges in simple images.",
+    ],
+  },
   sobelderivatives_prewittoperator: {
     name: "Prewitt Operator",
     description:


### PR DESCRIPTION
## Description
Adds a Roberts Cross edge detection operator to the Sobel Derivatives category. The backend applies two 2x2 diagonal gradient kernels (`Gx = [[1,0],[0,-1]]`, `Gy = [[0,1],[-1,0]]`) via `cv2.filter2D` and returns the gradient magnitude as a uint8 image. Colour images are automatically converted to grayscale. 

In reference to PR #196 
Fixes #195 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Ran the pipeline with a Roberts Cross block on both grayscale and colour images and confirmed correct edge detection output.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally