### PR TITLE
fix: resolve blank landing screen due to hashed css module animations

### DIFF
--- a/imagelab-frontend/src/components/LandingScreen.module.css
+++ b/imagelab-frontend/src/components/LandingScreen.module.css
@@ -1,32 +1,3 @@
-@keyframes float1 {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  50% {
-    transform: translate(30px, -40px) scale(1.05);
-  }
-}
-@keyframes float2 {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  50% {
-    transform: translate(-20px, 30px) scale(0.95);
-  }
-}
-@keyframes fadeUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 .startBtn:hover:not(:disabled) {
   background: linear-gradient(135deg, #7c3aed, #059669) !important;
   transform: translateY(-2px) !important;

--- a/imagelab-frontend/src/index.css
+++ b/imagelab-frontend/src/index.css
@@ -49,3 +49,34 @@
 .blocklyScrollbarVertical {
   display: none !important;
 }
+
+@keyframes float1 {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(30px, -40px) scale(1.05);
+  }
+}
+
+@keyframes float2 {
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  50% {
+    transform: translate(-20px, 30px) scale(0.95);
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Description

This PR resolves an issue where the new Landing Screen was displaying as a blank black screen with blurry orbs, rather than showing the intended text and buttons. 

The bug occurred because `@keyframes` (`fadeUp`, `float1`, `float2`) were defined inside a CSS Module (`LandingScreen.module.css`), which Vite automatically hashes. However, the `LandingScreen.tsx` component applies these animations via inline styles using hardcoded string names (e.g., `animation: "fadeUp 0.6s..."`), causing the animations to fail and leaving the content stuck at `opacity: 0`. 

**Changes:**
- Removed keyframe definitions from `LandingScreen.module.css`.
- Moved the `fadeUp`, `float1`, and `float2` keyframes to the global `index.css` stylesheet so they can be correctly targeted by the inline styles.

Fixes #325 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Verified that the animations now correctly execute and the landing screen fades in upon loading the app.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally