### PR TITLE
fix: filtering laplacian missing super init

### DIFF
--- a/imagelab-backend/app/operators/filtering/laplacian.py
+++ b/imagelab-backend/app/operators/filtering/laplacian.py
@@ -18,6 +18,7 @@ class Laplacian(BaseOperator):
     """
 
     def __init__(self, params: dict):
+        super().__init__(params)
         self._ksize = int(params.get("ksize", 1))
 
     def compute(self, image: np.ndarray) -> np.ndarray:

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -281,3 +281,14 @@ class TestLaplacian:
         edge_image[:, 25:] = 255
         result = Laplacian({}).compute(edge_image)
         assert result.sum() > 0
+
+    def test_params_stored_on_instance(self):
+        # super().__init__(params) must be called so self.params is accessible
+        op = Laplacian({"ksize": 3})
+        assert hasattr(op, "params")
+        assert op.params == {"ksize": 3}
+
+    def test_empty_params_stored_on_instance(self):
+        op = Laplacian({})
+        assert hasattr(op, "params")
+        assert op.params == {}


### PR DESCRIPTION
## Description
Adds the missing `super().__init__(params)` call in `app/operators/filtering/laplacian.py`. Without it, `self.params` is never set on the instance, violating the `BaseOperator` contract.
Fixes #328

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Added two new tests to `TestLaplacian` in `tests/test_filtering_operators.py`:
- `test_params_stored_on_instance` — confirms `self.params` is set and matches the passed dict
- `test_empty_params_stored_on_instance` — same for empty params

All 9 `TestLaplacian` tests pass.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally