### PR TITLE
fix: sobel scharr bgra crash

### DIFF
--- a/imagelab-backend/app/operators/sobel_derivatives/scharr_derivative.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/scharr_derivative.py
@@ -15,6 +15,9 @@ class ScharrDerivative(BaseOperator):
         if ddepth == 0:
             ddepth = cv2.CV_64F
 
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+
         result = cv2.Scharr(image, ddepth, 1, 0) if direction == "HORIZONTAL" else cv2.Scharr(image, ddepth, 0, 1)
 
         return cv2.convertScaleAbs(result)

--- a/imagelab-backend/app/operators/sobel_derivatives/sobel_derivative.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/sobel_derivative.py
@@ -15,6 +15,9 @@ class SobelDerivative(BaseOperator):
         if ddepth == 0:
             ddepth = cv2.CV_64F
 
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)
+
         if direction == "HORIZONTAL":
             result = cv2.Sobel(image, ddepth, 1, 0)
         elif direction == "VERTICAL":

--- a/imagelab-backend/tests/test_sobel_scharr.py
+++ b/imagelab-backend/tests/test_sobel_scharr.py
@@ -30,6 +30,21 @@ class TestSobelDerivative:
         assert result.shape == gray.shape
         assert result.dtype == np.uint8
 
+    def test_bgra_input_converted_to_bgr(self):
+        bgra = np.random.randint(0, 256, (48, 48, 4), dtype=np.uint8)
+        result = SobelDerivative({"type": "HORIZONTAL"}).compute(bgra)
+        assert result.dtype == np.uint8
+
+    def test_bgra_vertical(self):
+        bgra = np.random.randint(0, 256, (48, 48, 4), dtype=np.uint8)
+        result = SobelDerivative({"type": "VERTICAL"}).compute(bgra)
+        assert result.dtype == np.uint8
+
+    def test_bgra_both(self):
+        bgra = np.random.randint(0, 256, (48, 48, 4), dtype=np.uint8)
+        result = SobelDerivative({"type": "BOTH"}).compute(bgra)
+        assert result.dtype == np.uint8
+
 
 class TestScharrDerivative:
     def test_horizontal_dtype_and_range(self):
@@ -46,4 +61,14 @@ class TestScharrDerivative:
         gray = np.random.randint(0, 256, (48, 48), dtype=np.uint8)
         result = ScharrDerivative({"type": "HORIZONTAL"}).compute(gray)
         assert result.shape == gray.shape
+        assert result.dtype == np.uint8
+
+    def test_bgra_input_converted_to_bgr(self):
+        bgra = np.random.randint(0, 256, (48, 48, 4), dtype=np.uint8)
+        result = ScharrDerivative({"type": "HORIZONTAL"}).compute(bgra)
+        assert result.dtype == np.uint8
+
+    def test_bgra_vertical(self):
+        bgra = np.random.randint(0, 256, (48, 48, 4), dtype=np.uint8)
+        result = ScharrDerivative({"type": "VERTICAL"}).compute(bgra)
         assert result.dtype == np.uint8


### PR DESCRIPTION
## Description
Adds BGRA→BGR conversion in `SobelDerivative` and `ScharrDerivative` before calling `cv2.Sobel` / `cv2.Scharr`. Without it, passing a 4-channel BGRA image crashes OpenCV or produces garbage output.
Fixes #330

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Added BGRA tests to `TestSobelDerivative` and `TestScharrDerivative` in `tests/test_sobel_scharr.py`:
- `test_bgra_input_converted_to_bgr` — horizontal direction
- `test_bgra_vertical` — vertical direction
- `test_bgra_both` — combined direction (Sobel only)

All 12 tests pass.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locallyv