### PR TITLE
fix: validate filterSize in BilateralFilter to prevent OpenCV crash

### DIFF
--- a/imagelab-backend/app/operators/filtering/bilateral_filter.py
+++ b/imagelab-backend/app/operators/filtering/bilateral_filter.py
@@ -7,6 +7,8 @@ from app.operators.base import BaseOperator
 class BilateralFilter(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         filter_size = int(self.params.get("filterSize", 5))
+        if filter_size <= 0:
+            raise ValueError(f"filterSize must be a positive integer, got {filter_size}")
         sigma_color = float(self.params.get("sigmaColor", 75))
         sigma_space = float(self.params.get("sigmaSpace", 75))
         # Convert RGBA to BGR if needed

--- a/imagelab-backend/tests/test_filtering_operators.py
+++ b/imagelab-backend/tests/test_filtering_operators.py
@@ -52,6 +52,14 @@ class TestBilateralFilter:
         result = BilateralFilter({}).compute(color_image)
         assert result.dtype == np.uint8
 
+    def test_zero_filter_size_raises(self, color_image):
+        with pytest.raises(ValueError):
+            BilateralFilter({"filterSize": 0}).compute(color_image)
+
+    def test_negative_filter_size_raises(self, color_image):
+        with pytest.raises(ValueError):
+            BilateralFilter({"filterSize": -3}).compute(color_image)
+
 
 # BoxFilter
 
@@ -281,3 +289,14 @@ class TestLaplacian:
         edge_image[:, 25:] = 255
         result = Laplacian({}).compute(edge_image)
         assert result.sum() > 0
+
+    def test_params_stored_on_instance(self):
+        # super().__init__(params) must be called so self.params is accessible
+        op = Laplacian({"ksize": 3})
+        assert hasattr(op, "params")
+        assert op.params == {"ksize": 3}
+
+    def test_empty_params_stored_on_instance(self):
+        op = Laplacian({})
+        assert hasattr(op, "params")
+        assert op.params == {}


### PR DESCRIPTION
## Description
Adds validation for `filterSize` in `app/operators/filtering/bilateral_filter.py`. Without it, passing `0` or a negative value crashes `cv2.bilateralFilter` with an unhandled OpenCV exception.
Fixes #332

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Existing tests pass
- [x] New tests added
- [x] Manual testing

Added two new tests to `TestBilateralFilter` in `tests/test_filtering_operators.py`:
- `test_zero_filter_size_raises` — confirms `ValueError` on `filterSize=0`
- `test_negative_filter_size_raises` — confirms `ValueError` on `filterSize=-3`

All 7 `TestBilateralFilter` tests pass.

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally