### PR TITLE
Fixed invisible landing screen

### DIFF
--- a/imagelab-frontend/src/components/LandingScreen.module.css
+++ b/imagelab-frontend/src/components/LandingScreen.module.css
@@ -27,6 +27,52 @@
   }
 }
 
+.orbFloat1 {
+  animation: float1 8s ease-in-out infinite;
+}
+
+.orbFloat1Reverse {
+  animation: float1 12s ease-in-out infinite reverse;
+}
+
+.orbFloat2 {
+  animation: float2 10s ease-in-out infinite;
+}
+
+.fadeUpDelay1,
+.fadeUpDelay2,
+.fadeUpDelay3,
+.fadeUpDelay4,
+.fadeUpDelay5,
+.fadeUpDelay6 {
+  opacity: 0;
+  animation: fadeUp 0.6s ease forwards;
+}
+
+.fadeUpDelay1 {
+  animation-delay: 0.1s;
+}
+
+.fadeUpDelay2 {
+  animation-delay: 0.2s;
+}
+
+.fadeUpDelay3 {
+  animation-delay: 0.3s;
+}
+
+.fadeUpDelay4 {
+  animation-delay: 0.4s;
+}
+
+.fadeUpDelay5 {
+  animation-delay: 0.5s;
+}
+
+.fadeUpDelay6 {
+  animation-delay: 0.6s;
+}
+
 .startBtn:hover:not(:disabled) {
   background: linear-gradient(135deg, #7c3aed, #059669) !important;
   transform: translateY(-2px) !important;

--- a/imagelab-frontend/src/components/LandingScreen.tsx
+++ b/imagelab-frontend/src/components/LandingScreen.tsx
@@ -20,7 +20,7 @@ const ORBS = [
     width: "400px",
     height: "400px",
     background: "radial-gradient(circle, rgba(99,102,241,0.15) 0%, transparent 70%)",
-    animation: "float1 8s ease-in-out infinite",
+    className: "orbFloat1",
   },
   {
     bottom: "10%",
@@ -28,7 +28,7 @@ const ORBS = [
     width: "500px",
     height: "500px",
     background: "radial-gradient(circle, rgba(16,185,129,0.1) 0%, transparent 70%)",
-    animation: "float2 10s ease-in-out infinite",
+    className: "orbFloat2",
   },
   {
     top: "50%",
@@ -36,7 +36,7 @@ const ORBS = [
     width: "300px",
     height: "300px",
     background: "radial-gradient(circle, rgba(245,158,11,0.08) 0%, transparent 70%)",
-    animation: "float1 12s ease-in-out infinite reverse",
+    className: "orbFloat1Reverse",
   },
 ];
 
@@ -116,10 +116,11 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
         {transitioning ? "Loading workspace" : ""}
       </div>
 
-      {ORBS.map((orb, i) => (
+      {ORBS.map(({ className, ...orb }, i) => (
         <div
           key={i}
           aria-hidden="true"
+          className={styles[className as keyof typeof styles]}
           style={{
             position: "absolute",
             borderRadius: "50%",
@@ -157,12 +158,11 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
         }}
       >
         <div
+          className={visible ? styles.fadeUpDelay1 : undefined}
           style={{
             display: "flex",
             justifyContent: "center",
             marginBottom: "1.25rem",
-            animation: visible ? "fadeUp 0.6s 0.1s ease forwards" : "none",
-            opacity: 0,
           }}
         >
           <span
@@ -183,11 +183,10 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
         </div>
 
         <div
+          className={visible ? styles.fadeUpDelay2 : undefined}
           style={{
             textAlign: "center",
             marginBottom: "0.75rem",
-            animation: visible ? "fadeUp 0.6s 0.2s ease forwards" : "none",
-            opacity: 0,
           }}
         >
           <h1
@@ -228,23 +227,21 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
 
         <div
           aria-hidden="true"
+          className={visible ? styles.fadeUpDelay3 : undefined}
           style={{
             height: "1px",
             background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.1), transparent)",
             margin: "1rem 0",
-            animation: visible ? "fadeUp 0.6s 0.3s ease forwards" : "none",
-            opacity: 0,
           }}
         />
 
         <div
+          className={visible ? styles.fadeUpDelay4 : undefined}
           style={{
             display: "flex",
             flexDirection: "column",
             gap: "0.5rem",
             marginBottom: "1rem",
-            animation: visible ? "fadeUp 0.6s 0.4s ease forwards" : "none",
-            opacity: 0,
           }}
         >
           {STEPS.map(({ num, title, desc, color }) => (
@@ -308,12 +305,7 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
           ))}
         </div>
 
-        <div
-          style={{
-            animation: visible ? "fadeUp 0.6s 0.5s ease forwards" : "none",
-            opacity: 0,
-          }}
-        >
+        <div className={visible ? styles.fadeUpDelay5 : undefined}>
           <button
             ref={buttonRef}
             className={styles.startBtn}
@@ -341,13 +333,12 @@ export function LandingScreen({ onStart }: LandingScreenProps) {
         </div>
 
         <div
+          className={visible ? styles.fadeUpDelay6 : undefined}
           style={{
             display: "flex",
             justifyContent: "center",
             marginTop: "0.6rem",
             marginBottom: "0.5rem",
-            animation: visible ? "fadeUp 0.6s 0.6s ease forwards" : "none",
-            opacity: 0,
           }}
         >
           <label


### PR DESCRIPTION
## Description

Brief summary of the changes. Reference any related issues.
LandingScreen.tsx was using inline animation strings like animation: "fadeUp 0.6s ..." while fadeUp, float1, and float2 were defined inside LandingScreen.module.css.

CSS Modules locally scope names, including keyframes. So the real generated keyframe name becomes something like LandingScreen_fadeUp__abc123, but the inline style still asks the browser for plain fadeUp. The browser can’t find it, so the elements that start at opacity: 0 never animate in. Blank-looking screen.

Fixes #334 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots 
<img width="1280" height="564" alt="image" src="https://github.com/user-attachments/assets/c6c2c9c1-140a-4e70-b200-bd617c931231" />

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [ ] Tests pass locally
