### PR TITLE
Validate filterSize in BilateralFilter

### DIFF
--- a/imagelab-backend/app/operators/filtering/bilateral_filter.py
+++ b/imagelab-backend/app/operators/filtering/bilateral_filter.py
@@ -2,6 +2,7 @@ import cv2
 import numpy as np
 
 from app.operators.base import BaseOperator
+from app.operators.blurring.validation import validate_positive_kernel_dim
 
 
 class BilateralFilter(BaseOperator):
@@ -9,6 +10,9 @@ class BilateralFilter(BaseOperator):
         filter_size = int(self.params.get("filterSize", 5))
         sigma_color = float(self.params.get("sigmaColor", 75))
         sigma_space = float(self.params.get("sigmaSpace", 75))
+
+        validate_positive_kernel_dim(filter_size, "filterSize")
+
         # Convert RGBA to BGR if needed
         if len(image.shape) == 3 and image.shape[2] == 4:
             image = cv2.cvtColor(image, cv2.COLOR_BGRA2BGR)

--- a/imagelab-backend/tests/operators/filtering/test_bilateral_filter.py
+++ b/imagelab-backend/tests/operators/filtering/test_bilateral_filter.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from app.operators.filtering.bilateral_filter import BilateralFilter
+
+
+@pytest.fixture
+def image():
+    return np.full((5, 5, 3), 128, dtype=np.uint8)
+
+
+class TestBilateralFilterValidInput:
+    def test_default_params_produce_output(self, image):
+        result = BilateralFilter({}).compute(image)
+        assert result.shape == image.shape
+        assert result.dtype == image.dtype
+
+    @pytest.mark.parametrize("size", [1, 3, 5, 9])
+    def test_positive_filter_sizes(self, image, size):
+        result = BilateralFilter({"filterSize": size}).compute(image)
+        assert result.shape == image.shape
+
+
+class TestBilateralFilterInvalidInput:
+    @pytest.mark.parametrize("bad_size", [0, -1, -5])
+    def test_non_positive_filter_size_raises(self, image, bad_size):
+        with pytest.raises(ValueError, match="'filterSize'"):
+            BilateralFilter({"filterSize": bad_size}).compute(image)


### PR DESCRIPTION
Fixes #332.

`BilateralFilter` read `filterSize` directly and passed it to `cv2.bilateralFilter`, which raises an OpenCV error on zero/negative values. All blurring operators (`Blur`, `GaussianBlur`, `MedianBlur`) validate their kernel size; this brings `BilateralFilter` in line by reusing `validate_positive_kernel_dim`, which raises a clear `ValueError`.

Added `tests/operators/filtering/test_bilateral_filter.py` covering valid and invalid inputs.