### PR TITLE
fix: convert BGRA to grayscale in SobelDerivative and ScharrDerivative

### DIFF
--- a/imagelab-backend/app/operators/sobel_derivatives/scharr_derivative.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/scharr_derivative.py
@@ -2,19 +2,23 @@ import cv2
 import numpy as np
 
 from app.operators.base import BaseOperator
+from app.operators.sobel_derivatives.sobel_derivative import _to_grayscale
 
 
 class ScharrDerivative(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         """Apply the Scharr derivative operator.
 
-        Returns a uint8 image with values in [0, 255].
+        Returns a uint8 grayscale image with values in [0, 255].
+        BGRA images are converted to grayscale before applying Scharr.
         """
         direction = self.params.get("type", "HORIZONTAL")
         ddepth = int(self.params.get("ddepth", 0))
         if ddepth == 0:
             ddepth = cv2.CV_64F
 
-        result = cv2.Scharr(image, ddepth, 1, 0) if direction == "HORIZONTAL" else cv2.Scharr(image, ddepth, 0, 1)
+        gray = _to_grayscale(image)
+
+        result = cv2.Scharr(gray, ddepth, 1, 0) if direction == "HORIZONTAL" else cv2.Scharr(gray, ddepth, 0, 1)
 
         return cv2.convertScaleAbs(result)

--- a/imagelab-backend/app/operators/sobel_derivatives/sobel_derivative.py
+++ b/imagelab-backend/app/operators/sobel_derivatives/sobel_derivative.py
@@ -4,24 +4,36 @@ import numpy as np
 from app.operators.base import BaseOperator
 
 
+def _to_grayscale(image: np.ndarray) -> np.ndarray:
+    """Convert image to grayscale, handling BGRA, BGR, and already-grayscale inputs."""
+    if image.ndim == 2:
+        return image
+    if image.shape[2] == 4:
+        return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+    return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+
 class SobelDerivative(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         """Apply the Sobel derivative operator.
 
-        Returns a uint8 image with values in [0, 255].
+        Returns a uint8 grayscale image with values in [0, 255].
+        BGRA images are converted to grayscale before applying Sobel.
         """
         direction = self.params.get("type", "HORIZONTAL")
         ddepth = int(self.params.get("ddepth", 0))
         if ddepth == 0:
             ddepth = cv2.CV_64F
 
+        gray = _to_grayscale(image)
+
         if direction == "HORIZONTAL":
-            result = cv2.Sobel(image, ddepth, 1, 0)
+            result = cv2.Sobel(gray, ddepth, 1, 0)
         elif direction == "VERTICAL":
-            result = cv2.Sobel(image, ddepth, 0, 1)
+            result = cv2.Sobel(gray, ddepth, 0, 1)
         else:
-            sobel_x = cv2.Sobel(image, ddepth, 1, 0)
-            sobel_y = cv2.Sobel(image, ddepth, 0, 1)
+            sobel_x = cv2.Sobel(gray, ddepth, 1, 0)
+            sobel_y = cv2.Sobel(gray, ddepth, 0, 1)
             result = np.hypot(sobel_x, sobel_y)
 
         return cv2.convertScaleAbs(result)

--- a/imagelab-backend/tests/test_sobel_scharr.py
+++ b/imagelab-backend/tests/test_sobel_scharr.py
@@ -10,7 +10,7 @@ _GRAY[:, 32:] = 255
 # BGRA image with a vertical edge (4-channel with alpha)
 _BGRA = np.zeros((64, 64, 4), dtype=np.uint8)
 _BGRA[:, 32:, 0] = 255  # blue channel edge
-_BGRA[:, :, 3] = 128    # semi-transparent alpha
+_BGRA[:, :, 3] = 128  # semi-transparent alpha
 
 
 class TestSobelDerivative:

--- a/imagelab-backend/tests/test_sobel_scharr.py
+++ b/imagelab-backend/tests/test_sobel_scharr.py
@@ -7,6 +7,11 @@ from app.operators.sobel_derivatives.sobel_derivative import SobelDerivative
 _GRAY = np.zeros((64, 64), dtype=np.uint8)
 _GRAY[:, 32:] = 255
 
+# BGRA image with a vertical edge (4-channel with alpha)
+_BGRA = np.zeros((64, 64, 4), dtype=np.uint8)
+_BGRA[:, 32:, 0] = 255  # blue channel edge
+_BGRA[:, :, 3] = 128    # semi-transparent alpha
+
 
 class TestSobelDerivative:
     def test_horizontal_dtype_and_range(self):
@@ -30,6 +35,22 @@ class TestSobelDerivative:
         assert result.shape == gray.shape
         assert result.dtype == np.uint8
 
+    def test_bgra_input_produces_single_channel_output(self):
+        """BGRA images must be converted before Sobel — output should be 2D (grayscale), not 4-channel."""
+        result = SobelDerivative({"type": "HORIZONTAL"}).compute(_BGRA)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D output for BGRA input, got shape {result.shape}"
+
+    def test_bgra_vertical(self):
+        result = SobelDerivative({"type": "VERTICAL"}).compute(_BGRA)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D output for BGRA input, got shape {result.shape}"
+
+    def test_bgra_both(self):
+        result = SobelDerivative({"type": "BOTH"}).compute(_BGRA)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D output for BGRA input, got shape {result.shape}"
+
 
 class TestScharrDerivative:
     def test_horizontal_dtype_and_range(self):
@@ -47,3 +68,14 @@ class TestScharrDerivative:
         result = ScharrDerivative({"type": "HORIZONTAL"}).compute(gray)
         assert result.shape == gray.shape
         assert result.dtype == np.uint8
+
+    def test_bgra_input_produces_single_channel_output(self):
+        """BGRA images must be converted before Scharr — output should be 2D (grayscale), not 4-channel."""
+        result = ScharrDerivative({"type": "HORIZONTAL"}).compute(_BGRA)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D output for BGRA input, got shape {result.shape}"
+
+    def test_bgra_vertical(self):
+        result = ScharrDerivative({"type": "VERTICAL"}).compute(_BGRA)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D output for BGRA input, got shape {result.shape}"


### PR DESCRIPTION
## Summary

Fixes #330

When a 4-channel BGRA image (transparent PNG) is passed to SobelDerivative or ScharrDerivative, the operators apply cv2.Sobel / cv2.Scharr directly on all 4 channels including the alpha channel. This produces a corrupt 4-channel output instead of a proper grayscale edge map.

## Root cause

Neither operator converted the image to grayscale before applying the derivative. BGR images happened to produce usable results because OpenCV processes each channel, but BGRA images include the alpha channel in the computation, corrupting the output.

## Fix

Added a _to_grayscale() helper that handles 2D (already grayscale), BGR (3-channel), and BGRA (4-channel) inputs. Both operators now convert to grayscale before applying the derivative filter.

`python
def _to_grayscale(image: np.ndarray) -> np.ndarray:
    if image.ndim == 2:
        return image
    if image.shape[2] == 4:
        return cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
    return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
`

## Testing

5 new tests added to 	ests/test_sobel_scharr.py:

- TestSobelDerivative::test_bgra_input_produces_single_channel_output
- TestSobelDerivative::test_bgra_vertical
- TestSobelDerivative::test_bgra_both
- TestScharrDerivative::test_bgra_input_produces_single_channel_output
- TestScharrDerivative::test_bgra_vertical

All 12 tests pass (7 existing + 5 new). Full suite: 667 passed.