### PR TITLE
fix: raise ValueError for zero or negative scale in RotateImage

### DIFF
--- a/imagelab-backend/app/operators/geometric/rotate_image.py
+++ b/imagelab-backend/app/operators/geometric/rotate_image.py
@@ -8,6 +8,13 @@ class RotateImage(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         angle = float(self.params.get("angle", 90))
         scale = float(self.params.get("scale", 1))
+
+        if scale <= 0:
+            raise ValueError(
+                f"RotateImage: scale must be a positive number, got {scale}. "
+                "Use a value greater than 0 (e.g. 1.0 for original size, 0.5 to shrink, 2.0 to enlarge)."
+            )
+
         rows, cols = image.shape[:2]
         center = (cols / 2, rows / 2)
         M = cv2.getRotationMatrix2D(center, angle, scale)

--- a/imagelab-backend/tests/test_rotate_image.py
+++ b/imagelab-backend/tests/test_rotate_image.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.rotate_image import RotateImage
+
+
+@pytest.fixture
+def color_image():
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    img[40:60, 40:60] = [0, 255, 0]  # green square in center
+    return img
+
+
+class TestRotateImage:
+    def test_basic_rotation_preserves_shape(self, color_image):
+        result = RotateImage({"angle": 45, "scale": 1}).compute(color_image)
+        assert result.shape == color_image.shape
+        assert result.dtype == np.uint8
+
+    def test_rotation_360_matches_original(self, color_image):
+        result = RotateImage({"angle": 360, "scale": 1}).compute(color_image)
+        assert result.shape == color_image.shape
+        assert result.dtype == np.uint8
+
+    def test_default_params(self, color_image):
+        result = RotateImage({}).compute(color_image)
+        assert result.shape == color_image.shape
+        assert result.dtype == np.uint8
+
+    def test_scale_zero_raises_or_clamps(self, color_image):
+        """scale=0 silently destroys the image — should raise ValueError or clamp to a minimum."""
+        with pytest.raises(ValueError, match="scale"):
+            RotateImage({"angle": 45, "scale": 0}).compute(color_image)
+
+    def test_scale_negative_raises(self, color_image):
+        """Negative scale produces a distorted result — should raise ValueError."""
+        with pytest.raises(ValueError, match="scale"):
+            RotateImage({"angle": 45, "scale": -1}).compute(color_image)
+
+    def test_valid_scale_produces_correct_output(self, color_image):
+        result = RotateImage({"angle": 0, "scale": 1}).compute(color_image)
+        assert result.shape == color_image.shape
+        assert result.dtype == np.uint8
+
+    def test_grayscale_input(self):
+        gray = np.full((100, 100), 128, dtype=np.uint8)
+        result = RotateImage({"angle": 90, "scale": 1}).compute(gray)
+        assert result.shape == gray.shape
+        assert result.dtype == np.uint8


### PR DESCRIPTION
## Summary

Fixes #320

The Rotate Image block accepts a scale parameter that controls how much the image is zoomed during rotation. Passing scale=0 or a negative value silently corrupts the output with no error message shown to the user.

## What was wrong

RotateImage.compute() passed the scale value directly to cv2.getRotationMatrix2D() without any validation. OpenCV accepts scale=0 without crashing — it produces a mathematically valid transformation matrix that collapses every pixel to a uniform colour. Negative values produce a mirrored and distorted output. In both cases the pipeline reports success, the user sees a broken image, and has no idea why.

## To Reproduce

1. Open the app at http://localhost:3100
2. Upload any image using the Read Image block
3. Add a **Geometric > Rotate Image** block
4. Set the **scale** field to 0 (or any negative number)
5. Click **Run**

**Expected:** An error message telling the user that scale must be a positive number.

**Actual:** The pipeline succeeds and the processed panel shows a flat, uniformly coloured rectangle — all image detail is destroyed with no feedback.

## Fix

Added a validation check at the start of compute() that raises ValueError with a descriptive message when scale <= 0. The pipeline executor catches this and surfaces it as a step error in the UI so the user knows exactly what went wrong.

`python
if scale <= 0:
    raise ValueError(
        f'RotateImage: scale must be a positive number, got {scale}. '
        'Use a value greater than 0 (e.g. 1.0 for original size, 0.5 to shrink, 2.0 to enlarge).'
    )
`

## Tests

New test file 	ests/test_rotate_image.py with 7 tests covering:

- scale=0 raises ValueError
- scale=-1 raises ValueError
- Valid rotation at 45 degrees preserves shape and dtype
- 360 degree rotation
- Default parameters work correctly
- Grayscale image input handled correctly

Full suite: 674 passed, lint clean.