### PR TITLE
fix: convert BGR/BGRA to grayscale in GrayToBinary before thresholding

### DIFF
--- a/imagelab-backend/app/operators/conversions/gray_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/gray_to_binary.py
@@ -8,5 +8,15 @@ class GrayToBinary(BaseOperator):
     def compute(self, image: np.ndarray) -> np.ndarray:
         threshold_value = float(self.params.get("thresholdValue", 127))
         max_value = float(self.params.get("maxValue", 255))
+
+        # Convert color images to grayscale before thresholding.
+        # Passing a BGR or BGRA image directly to cv2.threshold produces a
+        # multi-channel binary output instead of a proper grayscale binary image.
+        if image.ndim == 3:
+            if image.shape[2] == 4:
+                image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
+            else:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
         _, dst = cv2.threshold(image, threshold_value, max_value, cv2.THRESH_BINARY)
         return dst

--- a/imagelab-backend/tests/test_conversion_operators.py
+++ b/imagelab-backend/tests/test_conversion_operators.py
@@ -82,6 +82,24 @@ class TestGrayToBinary:
         result = GrayToBinary({"thresholdValue": 127, "maxValue": 255}).compute(grayscale_image)
         assert result.dtype == np.uint8
 
+    def test_color_bgr_input_produces_grayscale_output(self):
+        """BGR images should be converted to grayscale before thresholding — not produce 3-channel binary."""
+        color = np.full((100, 100, 3), 128, dtype=np.uint8)
+        color[50:, :] = [200, 200, 200]
+        result = GrayToBinary({}).compute(color)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D grayscale output for BGR input, got shape {result.shape}"
+        assert set(np.unique(result)).issubset({0, 255})
+
+    def test_color_bgra_input_produces_grayscale_output(self):
+        """BGRA images should be converted to grayscale before thresholding — not produce 4-channel binary."""
+        bgra = np.full((100, 100, 4), 128, dtype=np.uint8)
+        bgra[50:, :] = [200, 200, 200, 255]
+        result = GrayToBinary({}).compute(bgra)
+        assert result.dtype == np.uint8
+        assert result.ndim == 2, f"Expected 2D grayscale output for BGRA input, got shape {result.shape}"
+        assert set(np.unique(result)).issubset({0, 255})
+
 
 # ColorToBinary
 


### PR DESCRIPTION
## Summary

Fixes #319

The GrayToBinary operator is designed to threshold a grayscale image into a binary (black and white) image. When a color (BGR or BGRA) image is passed in, it applies cv2.threshold() directly on all channels and returns a 3 or 4-channel binary output instead of a proper 2D grayscale binary image.

## What was wrong

GrayToBinary.compute() passed the image directly to cv2.threshold() with no channel check. OpenCV happily thresholds multi-channel images per-channel, so the operator appeared to work but produced a result with the wrong number of channels — defeating the purpose of the operator.

## To Reproduce

1. Upload any color image
2. Add a **Conversions > Gray to Binary** block (without first converting to gray)
3. Click Run
4. The output has 3 channels instead of 1 — downstream operators expecting a grayscale binary image will behave incorrectly

## Fix

Added channel detection at the start of compute() that converts BGR and BGRA inputs to grayscale before thresholding, matching the operator's documented intent.

`python
if image.ndim == 3:
    if image.shape[2] == 4:
        image = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)
    else:
        image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
`

## Tests

2 new tests added to TestGrayToBinary in 	ests/test_conversion_operators.py:

- 	est_color_bgr_input_produces_grayscale_output — BGR input gives 2D output
- 	est_color_bgra_input_produces_grayscale_output — BGRA input gives 2D output

All 7 GrayToBinary tests pass. Full suite: 671 passed.