### PR TITLE
fix(conversions): default ColorToBinary maxValue to 255 (frontend + backend)

### DIFF
--- a/imagelab-backend/app/operators/conversions/color_to_binary.py
+++ b/imagelab-backend/app/operators/conversions/color_to_binary.py
@@ -14,7 +14,7 @@ class ColorToBinary(BaseOperator):
         threshold_type_name = self.params.get("thresholdType", "threshold_binary")
         threshold_type = THRESHOLD_TYPES.get(threshold_type_name, cv2.THRESH_BINARY)
         threshold_value = float(self.params.get("thresholdValue", 0))
-        max_value = float(self.params.get("maxValue", 0))
+        max_value = float(self.params.get("maxValue", 255))
 
         if len(image.shape) == 3 and image.shape[2] == 4:
             gray = cv2.cvtColor(image, cv2.COLOR_BGRA2GRAY)

--- a/imagelab-backend/tests/test_conversion_operators.py
+++ b/imagelab-backend/tests/test_conversion_operators.py
@@ -84,21 +84,23 @@ class TestGrayToBinary:
 
     def test_color_bgr_input_produces_grayscale_output(self):
         """BGR images should be converted to grayscale before thresholding — not produce 3-channel binary."""
-        color = np.full((100, 100, 3), 128, dtype=np.uint8)
-        color[50:, :] = [200, 200, 200]
+        # Values straddle the default threshold (127) so the split is observable
+        color = np.full((100, 100, 3), 50, dtype=np.uint8)  # below threshold -> 0
+        color[50:, :] = [200, 200, 200]  # above threshold -> 255
         result = GrayToBinary({}).compute(color)
         assert result.dtype == np.uint8
         assert result.ndim == 2, f"Expected 2D grayscale output for BGR input, got shape {result.shape}"
-        assert set(np.unique(result)).issubset({0, 255})
+        assert set(np.unique(result)) == {0, 255}
 
     def test_color_bgra_input_produces_grayscale_output(self):
         """BGRA images should be converted to grayscale before thresholding — not produce 4-channel binary."""
-        bgra = np.full((100, 100, 4), 128, dtype=np.uint8)
-        bgra[50:, :] = [200, 200, 200, 255]
+        # Values straddle the default threshold (127) so the split is observable
+        bgra = np.full((100, 100, 4), 50, dtype=np.uint8)  # below threshold -> 0
+        bgra[50:, :] = [200, 200, 200, 255]  # above threshold -> 255
         result = GrayToBinary({}).compute(bgra)
         assert result.dtype == np.uint8
         assert result.ndim == 2, f"Expected 2D grayscale output for BGRA input, got shape {result.shape}"
-        assert set(np.unique(result)).issubset({0, 255})
+        assert set(np.unique(result)) == {0, 255}
 
 
 # ColorToBinary
@@ -130,6 +132,14 @@ class TestColorToBinary:
     def test_output_is_uint8(self, color_image):
         result = ColorToBinary({"thresholdValue": 127, "maxValue": 255}).compute(color_image)
         assert result.dtype == np.uint8
+
+    def test_default_params_produce_non_black_output(self):
+        # Regression for #182: maxValue defaulted to 0, so every thresholded pixel
+        # was written as 0 and the whole output came back black.
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        img[50:, :] = 200  # above the default threshold of 0 -> 255
+        result = ColorToBinary({}).compute(img)
+        assert set(np.unique(result)) == {0, 255}
 
 
 # ColorMaps

--- a/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
+++ b/imagelab-frontend/src/blocks/definitions/conversions.blocks.ts
@@ -120,7 +120,7 @@ export const conversionsBlocks = [
       },
       { type: "input_dummy" },
       { type: "field_number", name: "thresholdValue", value: 0, min: 0 },
-      { type: "field_number", name: "maxValue", value: 0, min: 0 },
+      { type: "field_number", name: "maxValue", value: 255, min: 0 },
     ],
     inputsInline: false,
     previousStatement: null,


### PR DESCRIPTION
## Summary

Fixes #182: `ColorToBinary` defaults `maxValue` to `0`, producing a fully black output.

## Problem

`maxValue` was wrong in two places, and both had to change together.

**Backend** (`imagelab-backend/app/operators/conversions/color_to_binary.py`): `self.params.get("maxValue", 0)` fell back to `0` instead of `255`.

**Frontend** (`imagelab-frontend/src/blocks/definitions/conversions.blocks.ts`): the Blockly block declared `maxValue` with `value: 0`.

The frontend half is the one that actually bites. `extractPipeline` (`imagelab-frontend/src/hooks/usePipeline.ts`) serializes every named field's current value into the request unconditionally, so a freshly dragged block always sent `maxValue: 0` explicitly. Since `.get("maxValue", 255)` only falls back when the key is *absent*, fixing the backend alone would never have changed what the UI produces. The block definition is the de-facto default; the backend fallback only protects callers that hit the API without the UI.

With `maxValue = 0`, `cv2.threshold` writes `0` to every above-threshold pixel, so the output is entirely black and no error is surfaced.

## Changes

- `color_to_binary.py`: fallback `0` to `255`.
- `conversions.blocks.ts`: block field default `0` to `255`. This matches the sibling `GrayToBinary` block, which was already at `255`.
- New regression test `test_default_params_produce_non_black_output`, asserting default params yield a real `{0, 255}` split.
- Hardened the two existing `GrayToBinary` colour-input tests. Their pixel values (`128` and `200`) both sat above the default threshold of `127`, so the output collapsed to all-white and `issubset({0, 255})` passed without proving a binary split. Values now straddle the threshold and the assertion is an equality check.

## Verification

- Reproduced on `main`: `ColorToBinary({})` returns `[0]`.
- Mutation-checked the regression test: reverted the source fix, confirmed the test fails (`assert {np.uint8(0)} == {0, 255}`), restored it, confirmed it passes. The test cannot pass against the old default.
- Backend: 684 tests pass, `ruff check` and `ruff format --check` clean.
- Frontend: 93 tests pass, `tsc --noEmit` and `eslint` clean.

## How to reproduce the original bug

1. Open the app at http://localhost:3100 and upload any image.
2. Add a **Conversions > Color to Binary** block with default settings.
3. Click Run.

Before: the processed panel shows a completely black image, no error. After: a binary image.

## Notes

- Rebased onto `main` and squashed to one commit. The branch previously carried a `GrayToBinary` BGR/BGRA commit that duplicated #349, which had already merged and closed #319. That commit was byte-identical to `main` and was the source of the merge conflict, so it has been dropped. This PR no longer touches `gray_to_binary.py` and no longer relates to #319.
- Out of scope, filed separately: `thresholdValue` still defaults to `0`, so default params now yield a mostly-white image rather than a useful binary split. `thresholding_applythreshold` (`thresholding.blocks.ts:6`) has the identical `maxValue: 0` bug on a different block.
