### PR TITLE
Add CropImage operator test coverage

### DIFF
--- a/imagelab-backend/tests/operators/geometric/test_crop_image.py
+++ b/imagelab-backend/tests/operators/geometric/test_crop_image.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+
+from app.operators.geometric.crop_image import CropImage
+
+
+def _rgb_image() -> np.ndarray:
+    return np.arange(5 * 6 * 3, dtype=np.uint8).reshape(5, 6, 3)
+
+
+def test_crop_inside_image_returns_exact_slice() -> None:
+    image = _rgb_image()
+
+    result = CropImage({"x1": 1, "y1": 2, "x2": 5, "y2": 5}).compute(image)
+
+    assert result.shape == (3, 4, 3)
+    np.testing.assert_array_equal(result, image[2:5, 1:5])
+
+
+def test_out_of_bounds_coordinates_are_clamped() -> None:
+    image = _rgb_image()
+
+    result = CropImage({"x1": -3, "y1": -2, "x2": 99, "y2": 3}).compute(image)
+
+    assert result.shape == (3, 6, 3)
+    np.testing.assert_array_equal(result, image[:3, :])
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"x1": 2, "x2": 2},
+        {"x1": 4, "x2": 1},
+        {"y1": 3, "y2": 3},
+        {"y1": 4, "y2": 1},
+    ],
+)
+def test_empty_or_inverted_box_returns_original_image(params: dict[str, int]) -> None:
+    image = _rgb_image()
+
+    result = CropImage(params).compute(image)
+
+    np.testing.assert_array_equal(result, image)
+
+
+def test_default_parameters_return_full_single_channel_image() -> None:
+    image = np.arange(5 * 6, dtype=np.uint8).reshape(5, 6)
+
+    result = CropImage({}).compute(image)
+
+    assert result.shape == image.shape
+    np.testing.assert_array_equal(result, image)


### PR DESCRIPTION
## Description

Adds focused unit coverage for `CropImage`, including exact pixel selection, coordinate clamping, invalid boxes, default parameters, and RGB/grayscale inputs.

This is test coverage only; no production code or behavior is changed.

Fixes #185

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Test/quality improvement.

## How Has This Been Tested?

- `uv run --python 3.12 --frozen pytest -v tests/operators/geometric/test_crop_image.py` (7 passed)
- `uv run --python 3.12 --frozen pytest -q` (698 passed)
- `uv run --python 3.12 --frozen --extra dev ruff check .`
- `uv run --python 3.12 --frozen --extra dev ruff format --check .`
- Targeted reverse mutations for the lower clamp and invalid-box condition produced the expected focused-test failures.

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

## Screenshots (if applicable)

Not applicable (test-only change).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally