### PR TITLE
feat: Surface graph validation warnings in frontend before run (#197)

### DIFF
--- a/imagelab-frontend/src/components/Toolbar.tsx
+++ b/imagelab-frontend/src/components/Toolbar.tsx
@@ -31,6 +31,8 @@ import VersionHistoryModal from "./VersionHistoryModal";
 import BatchProcessingModal from "./BatchProcessingModal";
 import CreateMacroModal from "./modals/CreateMacroModal";
 import ConfirmDialog from "./ConfirmDialog";
+import ValidationWarningModal from "./ValidationWarningModal";
+import { validatePipelineGraph, type ValidationWarning } from "../utils/validatePipelineGraph";
 
 /** Three-phase selection state for 2-click macro range picking. */
 type SelectionPhase = "idle" | "selecting" | "waitingForEnd";
@@ -82,6 +84,8 @@ export default function Toolbar({ workspace }: ToolbarProps) {
   const [showBatchModal, setShowBatchModal] = useState(false);
   const [showCreateMacroModal, setShowCreateMacroModal] = useState(false);
   const [showNewWorkspaceConfirm, setShowNewWorkspaceConfirm] = useState(false);
+  const [showValidationWarningModal, setShowValidationWarningModal] = useState(false);
+  const [validationWarnings, setValidationWarnings] = useState<ValidationWarning[]>([]);
 
   // ── Fallback single-click selection (used outside range-selection mode) ────
   const [selectedBlocks, setSelectedBlocks] = useState<Blockly.Block[]>([]);
@@ -222,6 +226,23 @@ export default function Toolbar({ workspace }: ToolbarProps) {
       return;
     }
 
+    // Validate pipeline graph before execution
+    const validationResult = validatePipelineGraph(graph, 3);
+
+    if (!validationResult.valid && validationResult.warnings.length > 0) {
+      // Show validation warning modal
+      setValidationWarnings(validationResult.warnings);
+      setShowValidationWarningModal(true);
+      return;
+    }
+
+    // Proceed with execution
+    executeGraphPipeline(graph);
+  };
+
+  const executeGraphPipeline = async (graph: ReturnType<typeof extractExecutableGraph>) => {
+    if (!originalImage) return;
+
     setExecuting(true);
     setError(null);
     setTiming(null);
@@ -271,6 +292,19 @@ export default function Toolbar({ workspace }: ToolbarProps) {
     } finally {
       setExecuting(false);
     }
+  };
+
+  const handleRunAnyway = () => {
+    setShowValidationWarningModal(false);
+    if (workspace) {
+      const graph = extractExecutableGraph(workspace);
+      executeGraphPipeline(graph);
+    }
+  };
+
+  const handleCancelValidation = () => {
+    setShowValidationWarningModal(false);
+    setValidationWarnings([]);
   };
 
   // Shift+? opens the shortcuts modal
@@ -603,6 +637,13 @@ export default function Toolbar({ workspace }: ToolbarProps) {
           }}
         />
       )}
+
+      <ValidationWarningModal
+        isOpen={showValidationWarningModal}
+        warnings={validationWarnings}
+        onRunAnyway={handleRunAnyway}
+        onCancel={handleCancelValidation}
+      />
 
       <ConfirmDialog
         isOpen={showNewWorkspaceConfirm}

--- a/imagelab-frontend/src/components/ValidationWarningModal.tsx
+++ b/imagelab-frontend/src/components/ValidationWarningModal.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import type { ValidationWarning } from "../utils/validatePipelineGraph";
+
+interface ValidationWarningModalProps {
+  isOpen: boolean;
+  warnings: ValidationWarning[];
+  onRunAnyway: () => void;
+  onCancel: () => void;
+}
+
+export default function ValidationWarningModal({
+  isOpen,
+  warnings,
+  onRunAnyway,
+  onCancel,
+}: ValidationWarningModalProps) {
+  const runAnywayButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Focus the run anyway button when dialog opens
+      runAnywayButtonRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 backdrop-blur-xs"
+      onClick={onCancel}
+      role="presentation"
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="validation-dialog-title"
+        aria-describedby="validation-dialog-description"
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden border border-gray-200 dark:border-gray-700"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700 bg-amber-50 dark:bg-amber-950/20">
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={18} className="text-amber-600 dark:text-amber-500" />
+            <h2
+              id="validation-dialog-title"
+              className="text-sm font-semibold text-gray-800 dark:text-gray-100"
+            >
+              Pipeline Validation Warnings
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="p-1 rounded hover:bg-amber-100 dark:hover:bg-gray-700 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+            title="Close"
+            aria-label="Close"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-5 max-h-96 overflow-y-auto">
+          <p
+            id="validation-dialog-description"
+            className="text-sm text-gray-600 dark:text-gray-300 mb-4"
+          >
+            {warnings.length === 1
+              ? "We found a potential issue with your pipeline:"
+              : `We found ${warnings.length} potential issues with your pipeline:`}
+          </p>
+
+          <ul className="space-y-3">
+            {warnings.map((warning, index) => (
+              <li
+                key={index}
+                className="flex gap-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-950/10 border border-amber-200 dark:border-amber-900/30"
+              >
+                <AlertTriangle
+                  size={16}
+                  className="text-amber-600 dark:text-amber-500 flex-shrink-0 mt-0.5"
+                  aria-hidden="true"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-gray-700 dark:text-gray-200 break-words">
+                    {warning.message}
+                  </p>
+                  {warning.nodeId && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      Block ID: {warning.nodeId}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-4 p-3 rounded-lg bg-blue-50 dark:bg-blue-950/10 border border-blue-200 dark:border-blue-900/30">
+            <p className="text-xs text-gray-600 dark:text-gray-300">
+              <strong className="text-gray-800 dark:text-gray-100">Note:</strong> These warnings
+              help identify common mistakes before running your pipeline. You can still run the
+              pipeline if you believe the configuration is correct, but it may fail during
+              execution.
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 text-xs font-medium text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
+          >
+            Cancel and Fix
+          </button>
+          <button
+            ref={runAnywayButtonRef}
+            type="button"
+            onClick={onRunAnyway}
+            className="px-4 py-2 text-xs font-medium text-white bg-amber-600 hover:bg-amber-700 dark:bg-amber-600 dark:hover:bg-amber-700 rounded-lg transition-colors"
+          >
+            Run Anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/imagelab-frontend/src/utils/validatePipelineGraph.ts
+++ b/imagelab-frontend/src/utils/validatePipelineGraph.ts
@@ -1,0 +1,260 @@
+import type { PipelineGraph, GraphNode } from "../types/macro";
+
+export interface ValidationWarning {
+  nodeId: string;
+  nodeType: string;
+  message: string;
+  port?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  warnings: ValidationWarning[];
+  hasReadImage: boolean;
+}
+
+// Port specifications matching backend OPERATOR_PORT_SPECS
+const OPERATOR_PORT_SPECS: Record<string, Record<string, number[]>> = {
+  imageconvertions_grayimage: { image: [3, 4], input: [3, 4] },
+  imageconvertions_colortobinary: { image: [3, 4], input: [3, 4] },
+  imageconvertions_graytobinary: { image: [1], input: [1] },
+  imageconvertions_channelsplit: { image: [3, 4], input: [3, 4] },
+  imageconvertions_hsvtobgr: { image: [3], input: [3] },
+  imageconvertions_bgrtohsv: { image: [3, 4], input: [3, 4] },
+  imageconvertions_bgrtolab: { image: [3, 4], input: [3, 4] },
+  imageconvertions_labtobgr: { image: [3], input: [3] },
+  imageconvertions_bgrtoycrcb: { image: [3, 4], input: [3, 4] },
+  imageconvertions_ycrcbtobgr: { image: [3], input: [3] },
+  thresholding_adaptivethreshold: { image: [1], input: [1] },
+  thresholding_otsuthreshold: { image: [1], input: [1] },
+  merge_images: { image: [3, 4], mask: [1] },
+  blend_images: { image: [3, 4], mask: [1] },
+};
+
+// Output channel specifications matching backend OPERATOR_OUTPUT_CHANNELS
+const OPERATOR_OUTPUT_CHANNELS: Record<string, number> = {
+  imageconvertions_grayimage: 1,
+  imageconvertions_colortobinary: 1,
+  imageconvertions_graytobinary: 1,
+  imageconvertions_channelsplit: 1,
+  thresholding_applythreshold: 1,
+  thresholding_adaptivethreshold: 1,
+  thresholding_otsuthreshold: 1,
+  filtering_cannyedge: 3,
+  segmentation_watershed: 3,
+  transformation_distance: 1,
+};
+
+// Control flow operators with branch requirements
+const CONTROL_BRANCHES: Record<string, string[]> = {
+  macro_blend: ["left", "right"],
+  macro_if_else: ["then", "else"],
+};
+
+function getNodeType(node: GraphNode): string {
+  return node.type || node.op || "";
+}
+
+function topologicalSort(graph: PipelineGraph): string[] {
+  const inDegree: Record<string, number> = {};
+  const adj: Record<string, string[]> = {};
+
+  // Initialize
+  for (const node of graph.nodes) {
+    inDegree[node.id] = 0;
+    adj[node.id] = [];
+  }
+
+  // Build adjacency list and calculate in-degrees
+  for (const edge of graph.edges) {
+    adj[edge.from].push(edge.to);
+    inDegree[edge.to] = (inDegree[edge.to] || 0) + 1;
+  }
+
+  // Collect nodes with no incoming edges
+  const queue: string[] = [];
+  for (const node of graph.nodes) {
+    if (inDegree[node.id] === 0) {
+      queue.push(node.id);
+    }
+  }
+
+  // Sort deterministically
+  queue.sort();
+
+  const result: string[] = [];
+  while (queue.length > 0) {
+    const nodeId = queue.shift()!;
+    result.push(nodeId);
+
+    const neighbors = adj[nodeId] || [];
+    const nextReady: string[] = [];
+
+    for (const neighbor of neighbors) {
+      inDegree[neighbor]--;
+      if (inDegree[neighbor] === 0) {
+        nextReady.push(neighbor);
+      }
+    }
+
+    // Add to queue in sorted order
+    nextReady.sort();
+    queue.push(...nextReady);
+  }
+
+  return result;
+}
+
+function getHumanReadableOperatorName(nodeType: string): string {
+  // Remove common prefixes
+  let cleanType = nodeType.replace(
+    /^(imageconvertions_|thresholding_|filtering_|morphological_|geometric_|segmentation_|transformation_|annotation_|drawing_)/,
+    "",
+  );
+
+  // Convert to title case with spaces
+  cleanType = cleanType
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+
+  return cleanType;
+}
+
+function getChannelTypeName(channels: number): string {
+  if (channels === 1) return "grayscale (1 channel)";
+  if (channels === 3) return "color (3 channels)";
+  if (channels === 4) return "color with alpha (4 channels)";
+  return `${channels} channels`;
+}
+
+/**
+ * Validates a pipeline graph for type mismatches and structural issues.
+ * Mirrors the backend _validate_graph logic in graph_engine.py.
+ *
+ * @param graph - The pipeline graph to validate
+ * @param inputChannels - Expected input channels (default: 3 for color)
+ * @param isNestedBranch - Whether this is a nested branch (skips Read Image check)
+ */
+export function validatePipelineGraph(
+  graph: PipelineGraph,
+  inputChannels: number = 3,
+  isNestedBranch: boolean = false,
+): ValidationResult {
+  const warnings: ValidationWarning[] = [];
+
+  // Check for Read Image block (only in root graph, not in branches)
+  const hasReadImage = graph.nodes.some((node) => {
+    const nodeType = getNodeType(node);
+    return nodeType === "basic_input" || nodeType === "readimage" || nodeType === "read_image";
+  });
+
+  if (!isNestedBranch && !hasReadImage && graph.nodes.length > 0) {
+    warnings.push({
+      nodeId: "",
+      nodeType: "",
+      message:
+        'No "Read Image" block found. Add a "Read Image" block to load an image into the pipeline.',
+    });
+  }
+
+  // Track output channels for each node
+  const outputs: Record<string, number> = {};
+  const nodes = new Map(graph.nodes.map((n) => [n.id, n]));
+
+  try {
+    const sortedNodes = topologicalSort(graph);
+
+    for (const nodeId of sortedNodes) {
+      const node = nodes.get(nodeId);
+      if (!node) continue;
+
+      const nodeType = getNodeType(node);
+
+      // Get incoming edges
+      const incoming = graph.edges.filter((edge) => edge.to === nodeId);
+
+      // Build port mapping
+      const ports: Record<string, number> = {};
+      for (const edge of incoming) {
+        const sourceChannels = outputs[edge.from];
+        if (sourceChannels !== undefined) {
+          const port = edge.input_port || "image";
+          ports[port] = sourceChannels;
+        }
+      }
+
+      // Determine primary input channels
+      let primary = inputChannels;
+      if (incoming.length > 0) {
+        // Try to find the primary port (None, image, or input)
+        primary = ports.image || ports.input || Object.values(ports)[0] || inputChannels;
+      }
+
+      // Validate port channels against specs
+      const portSpecs = OPERATOR_PORT_SPECS[nodeType];
+      if (portSpecs) {
+        for (const [port, channels] of Object.entries(ports)) {
+          const allowed = portSpecs[port] || portSpecs.image || portSpecs.input;
+          if (allowed && !allowed.includes(channels)) {
+            const humanName = getHumanReadableOperatorName(nodeType);
+            const expectedStr = allowed.map(getChannelTypeName).join(" or ");
+            const gotStr = getChannelTypeName(channels);
+
+            warnings.push({
+              nodeId,
+              nodeType,
+              port,
+              message: `"${humanName}" block expects ${expectedStr} but received ${gotStr}. Check the blocks connected before this one.`,
+            });
+          }
+        }
+      }
+
+      // Validate control flow branches
+      if (CONTROL_BRANCHES[nodeType]) {
+        const required = CONTROL_BRANCHES[nodeType];
+        const branchNames = Object.keys(node.branches || {});
+        const missingBranches = required.filter((name) => !branchNames.includes(name));
+
+        if (missingBranches.length > 0) {
+          const humanName = getHumanReadableOperatorName(nodeType);
+          warnings.push({
+            nodeId,
+            nodeType,
+            message: `"${humanName}" control block requires ${required.join(" and ")} branches, but ${missingBranches.join(", ")} ${missingBranches.length === 1 ? "is" : "are"} missing.`,
+          });
+        }
+
+        // Recursively validate branches
+        if (node.branches) {
+          for (const branchGraph of Object.values(node.branches)) {
+            if (typeof branchGraph === "object" && "nodes" in branchGraph) {
+              const branchResult = validatePipelineGraph(
+                branchGraph as PipelineGraph,
+                primary,
+                true,
+              );
+              warnings.push(...branchResult.warnings);
+            }
+          }
+        }
+      }
+
+      // Calculate output channels for this node
+      outputs[nodeId] = OPERATOR_OUTPUT_CHANNELS[nodeType] ?? primary;
+    }
+  } catch (error) {
+    // If topological sort fails (cycle), that's handled by backend
+    // We focus on type checking here
+    console.warn("Topological sort failed, skipping validation:", error);
+  }
+
+  return {
+    valid: warnings.length === 0,
+    warnings,
+    hasReadImage,
+  };
+}

--- a/imagelab-frontend/tests/utils/validatePipelineGraph.test.ts
+++ b/imagelab-frontend/tests/utils/validatePipelineGraph.test.ts
@@ -1,0 +1,341 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { validatePipelineGraph } from "../../src/utils/validatePipelineGraph";
+import type { PipelineGraph } from "../../src/types/macro";
+
+describe("validatePipelineGraph", () => {
+  describe("empty and valid pipelines", () => {
+    it("returns valid for an empty graph", () => {
+      const graph: PipelineGraph = { nodes: [], edges: [] };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("returns valid for a simple pipeline with Read Image", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "filtering_blur", op: "filtering_blur", params: {} },
+        ],
+        edges: [{ from: "1", to: "2" }],
+      };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+      expect(result.hasReadImage).toBe(true);
+    });
+
+    it("identifies Read Image block by various type names", () => {
+      const types = ["basic_input", "readimage", "read_image"];
+      
+      types.forEach((type) => {
+        const graph: PipelineGraph = {
+          nodes: [{ id: "1", type, op: type, params: {} }],
+          edges: [],
+        };
+        const result = validatePipelineGraph(graph);
+        expect(result.hasReadImage).toBe(true);
+      });
+    });
+  });
+
+  describe("missing Read Image block", () => {
+    it("warns when no Read Image block is present", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "filtering_blur", op: "filtering_blur", params: {} },
+          { id: "2", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+        ],
+        edges: [{ from: "1", to: "2" }],
+      };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(false);
+      expect(result.hasReadImage).toBe(false);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].message).toContain("No \"Read Image\" block found");
+    });
+  });
+
+  describe("channel type mismatches", () => {
+    it("detects grayscale output feeding into color-only operator", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+          { id: "3", type: "imageconvertions_bgrtohsv", op: "imageconvertions_bgrtohsv", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "2" },
+          { from: "2", to: "3" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      
+      const channelWarning = result.warnings.find((w) => w.nodeId === "3");
+      expect(channelWarning).toBeDefined();
+      expect(channelWarning?.message).toContain("grayscale");
+      expect(channelWarning?.message).toContain("color");
+    });
+
+    it("detects color output feeding into grayscale-only operator", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "thresholding_adaptivethreshold", op: "thresholding_adaptivethreshold", params: {} },
+        ],
+        edges: [{ from: "1", to: "2" }],
+      };
+      const result = validatePipelineGraph(graph, 3); // Color input (3 channels)
+      expect(result.valid).toBe(false);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      
+      const channelWarning = result.warnings.find((w) => w.nodeId === "2");
+      expect(channelWarning).toBeDefined();
+      expect(channelWarning?.message).toContain("grayscale");
+    });
+
+    it("accepts grayscale input for grayscale-only operators", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+          { id: "3", type: "thresholding_adaptivethreshold", op: "thresholding_adaptivethreshold", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "2" },
+          { from: "2", to: "3" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("accepts color input for color operators", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "imageconvertions_bgrtohsv", op: "imageconvertions_bgrtohsv", params: {} },
+          { id: "3", type: "imageconvertions_hsvtobgr", op: "imageconvertions_hsvtobgr", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "2" },
+          { from: "2", to: "3" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe("control flow branch validation", () => {
+    it("validates macro_blend requires left and right branches", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          {
+            id: "1",
+            type: "macro_blend",
+            op: "macro_blend",
+            params: {},
+            branches: {
+              left: { nodes: [], edges: [] },
+              // Missing right branch
+            },
+          },
+        ],
+        edges: [],
+      };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      
+      const branchWarning = result.warnings.find((w) => w.nodeId === "1");
+      expect(branchWarning).toBeDefined();
+      expect(branchWarning?.message).toContain("branch");
+    });
+
+    it("validates macro_if_else requires then and else branches", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          {
+            id: "1",
+            type: "macro_if_else",
+            op: "macro_if_else",
+            params: {},
+            branches: {
+              then: { nodes: [], edges: [] },
+              // Missing else branch
+            },
+          },
+        ],
+        edges: [],
+      };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(false);
+      
+      const branchWarning = result.warnings.find((w) => w.nodeId === "1");
+      expect(branchWarning).toBeDefined();
+      expect(branchWarning?.message).toContain("branch");
+    });
+
+    it("accepts control flow with correct branches", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "0", type: "basic_input", op: "basic_input", params: {} },
+          {
+            id: "1",
+            type: "macro_blend",
+            op: "macro_blend",
+            params: {},
+            branches: {
+              left: { nodes: [], edges: [] },
+              right: { nodes: [], edges: [] },
+            },
+          },
+        ],
+        edges: [{ from: "0", to: "1" }],
+      };
+      const result = validatePipelineGraph(graph);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  describe("complex pipelines", () => {
+    it("validates a multi-step pipeline with mixed channel types", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "filtering_blur", op: "filtering_blur", params: {} },
+          { id: "3", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+          { id: "4", type: "thresholding_applythreshold", op: "thresholding_applythreshold", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "2" },
+          { from: "2", to: "3" },
+          { from: "3", to: "4" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("detects multiple validation issues in one pipeline", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          // No Read Image block
+          { id: "1", type: "filtering_blur", op: "filtering_blur", params: {} },
+          { id: "2", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+          // Color-only operator after grayscale
+          { id: "3", type: "imageconvertions_bgrtohsv", op: "imageconvertions_bgrtohsv", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "2" },
+          { from: "2", to: "3" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(false);
+      expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+      expect(result.hasReadImage).toBe(false);
+    });
+  });
+
+  describe("port-specific validation", () => {
+    it("validates merge_images with correct mask port", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+          { id: "3", type: "merge_images", op: "merge_images", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "3", input_port: "image" },
+          { from: "2", to: "3", input_port: "mask" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toHaveLength(0);
+    });
+
+    it("detects incorrect mask port channel type", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "basic_input", op: "basic_input", params: {} }, // Color image as mask
+          { id: "3", type: "merge_images", op: "merge_images", params: {} },
+        ],
+        edges: [
+          { from: "1", to: "3", input_port: "image" },
+          { from: "2", to: "3", input_port: "mask" },
+        ],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(false);
+      
+      const maskWarning = result.warnings.find((w) => w.port === "mask");
+      expect(maskWarning).toBeDefined();
+    });
+  });
+
+  describe("recursive branch validation", () => {
+    it("validates nested branches in control flow", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          {
+            id: "2",
+            type: "macro_blend",
+            op: "macro_blend",
+            params: {},
+            branches: {
+              left: {
+                nodes: [
+                  { id: "3", type: "filtering_blur", op: "filtering_blur", params: {} },
+                  { id: "4", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+                  // Color-only operator after grayscale in branch
+                  { id: "5", type: "imageconvertions_bgrtohsv", op: "imageconvertions_bgrtohsv", params: {} },
+                ],
+                edges: [
+                  { from: "3", to: "4" },
+                  { from: "4", to: "5" },
+                ],
+              },
+              right: { nodes: [], edges: [] },
+            },
+          },
+        ],
+        edges: [{ from: "1", to: "2" }],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      expect(result.valid).toBe(false);
+      // Should catch the channel mismatch in the nested branch
+      expect(result.warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("topological sort edge cases", () => {
+    it("handles disconnected nodes gracefully", () => {
+      const graph: PipelineGraph = {
+        nodes: [
+          { id: "1", type: "basic_input", op: "basic_input", params: {} },
+          { id: "2", type: "filtering_blur", op: "filtering_blur", params: {} },
+          // Disconnected node
+          { id: "3", type: "imageconvertions_grayimage", op: "imageconvertions_grayimage", params: {} },
+        ],
+        edges: [{ from: "1", to: "2" }],
+      };
+      const result = validatePipelineGraph(graph, 3);
+      // Should not throw, should process what it can
+      expect(result.hasReadImage).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #197

## Summary

Adds a client-side validation pass that runs immediately when the user clicks Run. If the pipeline graph contains errors, a modal displays plain-language warnings before any request is sent to the backend. If the graph is valid, execution proceeds without any additional interaction.

## Changes

### New files

- imagelab-frontend/src/utils/validatePipelineGraph.ts - Validation logic that mirrors the backend OPERATOR_PORT_SPECS and OPERATOR_OUTPUT_CHANNELS constants, performs a topological sort, and tracks channel state through the pipeline.
- imagelab-frontend/src/components/ValidationWarningModal.tsx - Modal component that presents the warning list and offers two actions: dismiss to edit, or proceed with execution.
- imagelab-frontend/tests/utils/validatePipelineGraph.test.ts - 17 unit tests covering valid pipelines, channel mismatches, missing Read Image blocks, control flow branches, and edge cases.

### Modified files

- imagelab-frontend/src/components/Toolbar.tsx - Calls validatePipelineGraph inside handleRun before dispatching the execution request.

## Validation checks

- Channel type mismatches (grayscale to color and color to grayscale)
- Missing Read Image block when no image input is present
- Invalid connections on mask ports and multi-input operators
- Missing required branches on macro_blend and macro_if_else nodes
- Recursive validation of nested control flow branches

## Acceptance criteria

- [x] A validation pass runs before each execution request
- [x] Warnings are rendered in a modal as plain-language messages that name the affected blocks
- [x] The modal offers both a dismiss path (return to editing) and a proceed path (run anyway)
- [x] A missing Read Image block is reported through the modal, not a bare setError call
- [x] Channel warnings are derived from the same operator specs as the backend
- [x] Valid pipelines execute immediately with no modal
- [x] Tests cover at least one incompatible pipeline and one clean pipeline

## Testing

Run the automated test suite:


npm run test validatePipelineGraph


17 tests pass.

## Implementation notes

Frontend validation mirrors backend rules to prevent drift. Cycle detection is intentionally left to the backend, as it is uncommon and more expensive to implement correctly on the client. Nested branches inherit the parent input channel rather than requiring a Read Image block of their own.

## Related

- Backend validation: \imagelab-backend/app/services/graph_engine.py\ (\_validate_graph\, line 243)
- Operator specs: \imagelab-backend/app/services/graph_engine.py\ (\OPERATOR_PORT_SPECS\, line 18)
- Execution entry point: \imagelab-frontend/src/components/Toolbar.tsx\ (\handleRun\)